### PR TITLE
chore: Add glob to dependencies

### DIFF
--- a/scripts/generate-package
+++ b/scripts/generate-package
@@ -22,6 +22,7 @@ const packages = [
     packageRoot: path.join(root, './lib/node'),
     dependencies: [
       'autoprefixer',
+      'glob',
       'loader-utils',
       'lodash',
       'postcss',


### PR DESCRIPTION
This was a missing dependency that is used by the build package.

*Issue #, if available:*

*Description of changes:*
Added glob to the list of dependencies that gets injected into the generated packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
