### PR TITLE
feat: Add support for generating a stable hash for design tokens

### DIFF
--- a/src/build/file.ts
+++ b/src/build/file.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { promises as fsp } from 'fs';
 import { dirname } from 'path';
+import stringHash from 'string-hash';
 
 /**
  * Ensures directory before writing content to file.
@@ -12,4 +13,9 @@ export async function writeFile(path: string, content: any): Promise<void> {
   const dir = dirname(path);
   await fsp.mkdir(dir, { recursive: true });
   await fsp.writeFile(path, content);
+}
+
+export async function hashFileContent(path: string): Promise<string> {
+  const content = await fsp.readFile(path, 'utf-8').catch(() => '');
+  return stringHash(content).toString(36).slice(0, 5);
 }

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 export { buildThemedComponents, BuildThemedComponentsParams } from './public';
 export { buildThemedComponentsInternal, BuildThemedComponentsInternalParams } from './internal';
+export { hashFileContent as hashFileContentInternal } from './file';
 export {
   Theme,
   ThemePreset,

--- a/src/build/inline-stylesheets.ts
+++ b/src/build/inline-stylesheets.ts
@@ -7,19 +7,30 @@ import { InlineStylesheet } from './tasks/style';
 import { jsonToSass } from '../shared/utils';
 import { markGlobal } from './tasks/postcss/modules';
 
+export interface GetInlineStylesheetsParams {
+  primary: Theme;
+  secondary: Theme[];
+  resolution: SpecificResolution;
+  variablesMap: Record<string, string>;
+  propertiesMap: Record<string, string>;
+  neededTokens: string[];
+  tokenStylesSuffix?: string;
+}
+
 /**
  * Generates a list of inline stylesheets used during the SCSS compilation. The primary
  * theme defines the mappings the environment.
  * @returns inline stylesheets
  */
-export function getInlineStylesheets(
-  primary: Theme,
-  secondary: Theme[],
-  resolution: SpecificResolution,
-  variablesMap: Record<string, string>,
-  propertiesMap: Record<string, string>,
-  neededTokens: string[]
-): InlineStylesheet[] {
+export function getInlineStylesheets({
+  primary,
+  secondary,
+  resolution,
+  variablesMap,
+  propertiesMap,
+  neededTokens,
+  tokenStylesSuffix,
+}: GetInlineStylesheetsParams): InlineStylesheet[] {
   const declarations = createBuildDeclarations(
     primary,
     secondary,
@@ -41,7 +52,7 @@ export function getInlineStylesheets(
 
   const context = {
     url: 'awsui:environment',
-    contents: `$theme: ${primary.id};`,
+    contents: `$theme: ${primary.id};` + (tokenStylesSuffix ? `$token-styles-suffix: "${tokenStylesSuffix}";` : ''),
   };
 
   const resolvedTokens = {


### PR DESCRIPTION
*Description of changes:*

Some CSS declarations (CSS animation keyframes, maybe classnames in the future) need a stable suffix so that design tokens can refer to them by name. This adds support for taking a special file (internal/styles/global.scss), hashing its contents, and providing that hash to the SCSS code so that it can include them in the declaration names. It also exposes that hash function out of the package so that the design tokens can generate that hash on their end and include them in the token names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
