### PR TITLE
chore: Remove IE11 from browserslist config

### DIFF
--- a/src/build/tasks/postcss/index.ts
+++ b/src/build/tasks/postcss/index.ts
@@ -21,7 +21,6 @@ const browserslist = [
   'last 3 Firefox major versions',
   'last 3 Edge major versions',
   'last 3 Safari major versions',
-  'ie >= 11',
 ];
 
 export const postCSSAfterAll = (input: string, filename: string) => {


### PR DESCRIPTION
Description of changes:
Remove IE11 from browserlist config.

https://aws.amazon.com/blogs/aws/heads-up-aws-support-for-internet-explorer-11-is-ending/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.