### PR TITLE
chore: Remove Custom Property plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5665,21 +5665,6 @@
         }
       }
     },
-    "postcss-custom-properties": {
-      "version": "12.1.7",
-      "resolved": false,
-      "integrity": "sha512-N/hYP5gSoFhaqxi2DPCmvto/ZcRDVjE3T1LiAMzc/bg53hvhcHOLpXOHb526LzBBp5ZlAUhkuot/bfpmpgStJg==",
-      "requires": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "4.2.0",
-          "resolved": false,
-          "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-        }
-      }
-    },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": false,

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "files": [],
   "dependencies": {
-    "@cloudscape-design/browser-test-tools": "^3.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.17.7",
+    "@cloudscape-design/browser-test-tools": "^3.0.0",
     "@tsconfig/node12": "^1.0.9",
     "@types/jest": "^27.4.1",
     "@types/loader-utils": "^2.0.3",
@@ -47,7 +47,6 @@
     "lodash": "^4.17.21",
     "merge": "^2.1.1",
     "postcss": "^8.4.12",
-    "postcss-custom-properties": "^12.1.7",
     "postcss-discard-empty": "^5.1.1",
     "postcss-initial": "^3.0.4",
     "postcss-inline-svg": "^5.0.0",

--- a/scripts/generate-package
+++ b/scripts/generate-package
@@ -23,7 +23,6 @@ const packages = [
       'loader-utils',
       'lodash',
       'postcss',
-      'postcss-custom-properties',
       'postcss-discard-empty',
       'postcss-initial',
       'postcss-inline-svg',

--- a/src/build/__tests__/public.test.ts
+++ b/src/build/__tests__/public.test.ts
@@ -117,24 +117,6 @@ test('keeps module prefix consistent', async () => {
   expect(modulePrefix(current.root)).toEqual(modulePrefix(previous.root));
 });
 
-test('custom property fallback matches IE11 declaration', async () => {
-  const componentStyles = await loadFile(componentStylesPath(componentsOutputDir));
-
-  const root = postcss.parse(componentStyles);
-  root.walkDecls((decl) => {
-    const matches = decl.value.matchAll(/var\(--[a-z0-9-]*, (.*)\)/g);
-    for (const match of matches) {
-      const [_, fallback] = match;
-      const prev = decl.prev();
-      if (prev?.type === 'decl') {
-        expect(prev.value).toEqual(fallback);
-      } else {
-        throw new Error('No IE11 fallback generated');
-      }
-    }
-  });
-});
-
 test('inlines SVG as base URL', async () => {
   const componentStyles = await loadFile(componentStylesPath(componentsOutputDir));
 

--- a/src/build/tasks/postcss/index.ts
+++ b/src/build/tasks/postcss/index.ts
@@ -3,7 +3,6 @@
 import autoprefixer from 'autoprefixer';
 import path from 'path';
 import postcss from 'postcss';
-import postcssCustomProperties from 'postcss-custom-properties';
 import postCSSDiscardEmpty from 'postcss-discard-empty';
 import postCSSInitial from 'postcss-initial';
 import postCSSInlineSVG from 'postcss-inline-svg';
@@ -31,7 +30,6 @@ export const postCSSAfterAll = (input: string, filename: string) => {
     // Reset only inherited properties, such as color or font-size. Do not reset own properties,
     // like display or padding, so we could set them ourselves
     postCSSInitial({ reset: 'inherited', replace: true }),
-    postcssCustomProperties(),
     postCSSIncreaseSpecificity(),
     postCSSDiscardEmpty(),
   ]).process(input, { from: filename });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We recently removed IE11 from browserslists configuration, however we kept fallback PostCSS plugin for CSS Custom Properties. We are removing it here. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
