### PR TITLE
chore: Merge code coverage reports

### DIFF
--- a/jest.browser.config.js
+++ b/jest.browser.config.js
@@ -7,6 +7,7 @@ module.exports = merge.recursive(tsPreset, {
   testEnvironment: 'jsdom',
   moduleFileExtensions: ['js', 'ts'],
   collectCoverage: true,
+  coverageDirectory: 'coverage/browser',
   globals: {
     'ts-jest': {
       tsconfig: './tsconfig.test.json',

--- a/jest.build.config.js
+++ b/jest.build.config.js
@@ -6,6 +6,7 @@ const tsPreset = require('ts-jest/jest-preset');
 module.exports = merge.recursive(tsPreset, {
   testEnvironment: 'node',
   collectCoverage: true,
+  coverageDirectory: 'coverage/build',
   coveragePathIgnorePatterns: ['/__fixtures__/', '/out/', '/node_modules/'],
   globals: {
     'ts-jest': {

--- a/jest.integ.config.js
+++ b/jest.integ.config.js
@@ -7,6 +7,7 @@ module.exports = merge.recursive(tsPreset, {
   testEnvironment: 'jsdom',
   moduleFileExtensions: ['js', 'ts'],
   collectCoverage: true,
+  coverageDirectory: 'coverage/integ',
   globals: {
     'ts-jest': {
       tsconfig: './tsconfig.test.json',


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Make sure that all code coverage reports from the different `test:*` runs are saved in separate folders.
Putting them all in one `coverage` folder makes sure that codecov can merge all reports correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
