### PR TITLE
chore: Update unlock script for npm v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -518,21 +518,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
-    "node_modules/@cloudscape-design/browser-test-tools": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.13.tgz",
-      "integrity": "sha512-DddDytUQShvNph/g//HyilI8OmMh/7oS23a/+V37896q6uo3D2RUgPr3NTVClCr4XoYMKWMLxENTwjFVKpdiQQ==",
-      "dependencies": {
-        "@types/pngjs": "^6.0.1",
-        "aws-sdk": "^2.1233.0",
-        "get-stream": "^6.0.1",
-        "lodash": "^4.17.21",
-        "p-retry": "^4.6.2",
-        "pixelmatch": "^5.3.0",
-        "pngjs": "^6.0.0",
-        "webdriverio": "^7.25.2"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -10295,21 +10280,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
-    },
-    "@cloudscape-design/browser-test-tools": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.13.tgz",
-      "integrity": "sha512-DddDytUQShvNph/g//HyilI8OmMh/7oS23a/+V37896q6uo3D2RUgPr3NTVClCr4XoYMKWMLxENTwjFVKpdiQQ==",
-      "requires": {
-        "@types/pngjs": "^6.0.1",
-        "aws-sdk": "^2.1233.0",
-        "get-stream": "^6.0.1",
-        "lodash": "^4.17.21",
-        "p-retry": "^4.6.2",
-        "pixelmatch": "^5.3.0",
-        "pngjs": "^6.0.0",
-        "webdriverio": "^7.25.2"
-      }
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/scripts/unlock-packages.js
+++ b/scripts/unlock-packages.js
@@ -9,10 +9,22 @@ const fs = require('fs');
 const filename = require.resolve('../package-lock.json');
 const packageLock = require(filename);
 
-Object.keys(packageLock.packages).forEach((dependencyName) => {
-  if (dependencyName.startsWith('node_modules/@cloudscape-design/')) {
-    delete packageLock.dependencies[dependencyName];
-  }
-});
+if (packageLock.lockfileVersion !== 2) {
+  throw new Error('package-lock.json must have "lockfileVersion": 2');
+}
+
+function unlock(packages) {
+  Object.keys(packages).forEach((dependencyName) => {
+    if (dependencyName.includes('@cloudscape-design/')) {
+      delete packages[dependencyName];
+    }
+  });
+
+  return packages;
+}
+
+packageLock.packages = unlock(packageLock.packages);
+packageLock.dependencies = unlock(packageLock.dependencies);
+
 fs.writeFileSync(filename, JSON.stringify(packageLock, null, 2) + '\n');
 console.log('Removed @cloudscape-design/ dependencies from package-lock file');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change makes sure that the unlock script works with the new `package-lock.json` format in npm v8.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
