### PR TITLE
chore: Remove cloudscape deps from package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -518,21 +518,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
-    "node_modules/@cloudscape-design/browser-test-tools": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.16.tgz",
-      "integrity": "sha512-+pImOU++cA3zSwL7Jn5oALfKnBtFUF0D/BXv3L+hbMboeHxKyIGppTU0iUg3/rcWh2oKim6Jzp7mfG6tDO8j3g==",
-      "dependencies": {
-        "@types/pngjs": "^6.0.1",
-        "aws-sdk": "^2.1233.0",
-        "get-stream": "^6.0.1",
-        "lodash": "^4.17.21",
-        "p-retry": "^4.6.2",
-        "pixelmatch": "^5.3.0",
-        "pngjs": "^6.0.0",
-        "webdriverio": "^7.25.2"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -10295,21 +10280,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
-    },
-    "@cloudscape-design/browser-test-tools": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@cloudscape-design/browser-test-tools/-/browser-test-tools-3.0.16.tgz",
-      "integrity": "sha512-+pImOU++cA3zSwL7Jn5oALfKnBtFUF0D/BXv3L+hbMboeHxKyIGppTU0iUg3/rcWh2oKim6Jzp7mfG6tDO8j3g==",
-      "requires": {
-        "@types/pngjs": "^6.0.1",
-        "aws-sdk": "^2.1233.0",
-        "get-stream": "^6.0.1",
-        "lodash": "^4.17.21",
-        "p-retry": "^4.6.2",
-        "pixelmatch": "^5.3.0",
-        "pngjs": "^6.0.0",
-        "webdriverio": "^7.25.2"
-      }
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Regenerate package-lock.

This [PR](https://github.com/cloudscape-design/theming-core/pull/31) from dependabot added the cloudscape packages to the package-lock file. The change is a mistake due to the way the `preinstall` npm script was changed in npm 8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
