### PR TITLE
fix: Specificity for main declaration in runtime theming for secondar…

### DIFF
--- a/src/browser/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/browser/__tests__/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`with baseThemeId attaches one style node containing overrides with the correct theme selector 1`] = `
-".secondary-theme.secondary-theme{
+".secondary-theme.secondary-theme:not(#\\\\9){
 	--fontFamilyBase-css:\\"Helvetica Neue\\", Arial, sans-serif;
 	--fontFamilyBody-css:\\"Helvetica Neue\\", Arial, sans-serif;
 	--black-css:purple;

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -29,7 +29,7 @@ export function applyTheme(params: ApplyThemeParams): ApplyThemeResult {
     theme,
     validated,
     preset.propertiesMap,
-    createMultiThemeCustomizer(theme.selector)
+    createMultiThemeCustomizer(preset.theme.selector)
   );
   const nonce = getNonce();
   const styleNode = createStyleNode(content, nonce);


### PR DESCRIPTION
…y themes

Main override lacked specificity.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
