### PR TITLE
fix: Generate TS declarations to also include contexts for secondary …

### DIFF
--- a/src/__fixtures__/common.ts
+++ b/src/__fixtures__/common.ts
@@ -64,6 +64,21 @@ export const navigationContext: Context = {
   },
 };
 
+const anotherContext: Context = {
+  id: 'another-context',
+  selector: '.another-context',
+  tokens: {
+    shadow: {
+      light: '{black}', // example of a reference
+      dark: '{brown}',
+    },
+    boxShadow: {
+      dark: 'purple', // example of a literal value
+      light: 'purple',
+    },
+  },
+};
+
 const emptyTheme: Theme = {
   id: 'root',
   selector: ':root',
@@ -144,6 +159,18 @@ export const secondaryTheme: Theme = {
           dark: '{grey}',
         },
       },
+    },
+  },
+};
+
+const anotherSecondaryTheme: Theme = {
+  ...secondaryTheme,
+  contexts: {
+    navigation: {
+      ...navigationContext,
+    },
+    'another-context': {
+      ...anotherContext,
     },
   },
 };
@@ -302,4 +329,8 @@ export const preset: ThemePreset = {
 export const presetWithSecondaryTheme: ThemePreset = {
   ...preset,
   secondary: [secondaryTheme],
+};
+export const anotherPresetWithSecondaryTheme: ThemePreset = {
+  ...preset,
+  secondary: [anotherSecondaryTheme],
 };

--- a/src/build/tasks/__tests__/__snapshots__/preset.test.ts.snap
+++ b/src/build/tasks/__tests__/__snapshots__/preset.test.ts.snap
@@ -25,6 +25,39 @@ export declare const preset: ThemePreset;
 "
 `;
 
+exports[`renderCJSDeclaration with secondary theme matches previous snapshot 1`] = `
+"import { ThemePreset, GlobalValue, TypedModeValueOverride } from '@cloudscape-design/theming-build';
+
+export declare interface TypedOverride {
+  tokens: {
+    shadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+    boxShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+    buttonShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+    lineShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+  },
+  contexts?: {
+    'navigation'?: {
+      tokens: {
+        shadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        boxShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        buttonShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        lineShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+      }
+    };
+    'another-context'?: {
+      tokens: {
+        shadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        boxShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        buttonShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        lineShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+      }
+    }
+  }
+}
+export declare const preset: ThemePreset;
+"
+`;
+
 exports[`renderCJSPreset matches previous snapshot 1`] = `
 "module.exports.preset = {
   \\"theme\\": {
@@ -184,6 +217,39 @@ export declare interface TypedOverride {
   },
   contexts?: {
     'navigation'?: {
+      tokens: {
+        shadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        boxShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        buttonShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        lineShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+      }
+    }
+  }
+}
+export declare const preset: ThemePreset;
+"
+`;
+
+exports[`renderDeclaration with secondary theme matches previous snapshot 1`] = `
+"import { ThemePreset, GlobalValue, TypedModeValueOverride } from '@cloudscape-design/theming-runtime';
+
+export declare interface TypedOverride {
+  tokens: {
+    shadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+    boxShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+    buttonShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+    lineShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+  },
+  contexts?: {
+    'navigation'?: {
+      tokens: {
+        shadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        boxShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        buttonShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+        lineShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
+      }
+    };
+    'another-context'?: {
       tokens: {
         shadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;
         boxShadow?: GlobalValue | TypedModeValueOverride<'light' | 'dark'>;

--- a/src/build/tasks/__tests__/preset.test.ts
+++ b/src/build/tasks/__tests__/preset.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { preset } from '../../../__fixtures__/common';
+import { preset, anotherPresetWithSecondaryTheme } from '../../../__fixtures__/common';
 import { renderPreset, renderCJSPreset, renderPresetDeclaration, renderCJSPresetDeclaration } from '../preset';
 
 test('renderPreset matches previous snapshot', () => {
@@ -12,9 +12,17 @@ test('renderCJSPreset matches previous snapshot', () => {
 });
 
 test('renderDeclaration matches previous snapshot', () => {
-  expect(renderPresetDeclaration(preset.theme, preset.themeable)).toMatchSnapshot();
+  expect(renderPresetDeclaration(preset)).toMatchSnapshot();
 });
 
 test('renderCJSDeclaration matches previous snapshot', () => {
-  expect(renderCJSPresetDeclaration(preset.theme, preset.themeable)).toMatchSnapshot();
+  expect(renderCJSPresetDeclaration(preset)).toMatchSnapshot();
+});
+
+test('renderDeclaration with secondary theme matches previous snapshot', () => {
+  expect(renderPresetDeclaration(anotherPresetWithSecondaryTheme)).toMatchSnapshot();
+});
+
+test('renderCJSDeclaration with secondary theme matches previous snapshot', () => {
+  expect(renderCJSPresetDeclaration(anotherPresetWithSecondaryTheme)).toMatchSnapshot();
 });

--- a/src/build/tasks/preset.ts
+++ b/src/build/tasks/preset.ts
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { join } from 'path';
-import { ThemePreset, Theme } from '../../shared/theme';
+import { ThemePreset } from '../../shared/theme';
 import { getMode } from '../../shared/theme/utils';
+import { getContexts } from '../../shared/theme/validate';
 import { writeFile } from '../file';
 
 const generatedThemingDir = 'internal/generated/theming';
@@ -12,8 +13,8 @@ export async function createPresetFiles(preset: ThemePreset, outputDir: string) 
   await Promise.all([
     writeFile(join(generatedDir, '/index.js'), renderPreset(preset)),
     writeFile(join(generatedDir, '/index.cjs'), renderCJSPreset(preset)),
-    writeFile(join(generatedDir, '/index.d.ts'), renderPresetDeclaration(preset.theme, preset.themeable)),
-    writeFile(join(generatedDir, '/index.cjs.d.ts'), renderCJSPresetDeclaration(preset.theme, preset.themeable)),
+    writeFile(join(generatedDir, '/index.d.ts'), renderPresetDeclaration(preset)),
+    writeFile(join(generatedDir, '/index.cjs.d.ts'), renderCJSPresetDeclaration(preset)),
   ]);
 }
 
@@ -25,25 +26,25 @@ export function renderCJSPreset(preset: ThemePreset): string {
   return `module.exports.preset = ${JSON.stringify(preset, null, 2)};\n`;
 }
 
-export function renderPresetDeclaration(theme: Theme, themeableTokens: string[]): string {
+export function renderPresetDeclaration(preset: ThemePreset): string {
   return `import { ThemePreset, GlobalValue, TypedModeValueOverride } from '@cloudscape-design/theming-runtime';
 
-export declare ${renderTypedOverrideInterface(theme, themeableTokens)}
+export declare ${renderTypedOverrideInterface(preset)}
 export declare const preset: ThemePreset;
 `;
 }
 
-export function renderCJSPresetDeclaration(theme: Theme, themeableTokens: string[]): string {
+export function renderCJSPresetDeclaration(preset: ThemePreset): string {
   return `import { ThemePreset, GlobalValue, TypedModeValueOverride } from '@cloudscape-design/theming-build';
 
-export declare ${renderTypedOverrideInterface(theme, themeableTokens)}
+export declare ${renderTypedOverrideInterface(preset)}
 export declare const preset: ThemePreset;
 `;
 }
 
-function renderTypedOverrideInterface(theme: Theme, themeableTokens: string[]): string {
-  const tokens = themeableTokens.map((token) => {
-    const mode = getMode(theme, token);
+function renderTypedOverrideInterface(preset: ThemePreset): string {
+  const tokens = preset.themeable.map((token) => {
+    const mode = getMode(preset.theme, token);
     if (mode) {
       const states = Object.keys(mode.states);
       return `${token}?: GlobalValue | TypedModeValueOverride<${states.map((state) => `'${state}'`).join(' | ')}>`;
@@ -52,7 +53,7 @@ function renderTypedOverrideInterface(theme: Theme, themeableTokens: string[]): 
     }
   });
 
-  const contexts = Object.keys(theme.contexts).map((contextId) => {
+  const contexts = getContexts(preset).map((contextId) => {
     return `'${contextId}'?: {
       tokens: {
         ${tokens.join(';\n        ')};

--- a/src/shared/theme/validate.ts
+++ b/src/shared/theme/validate.ts
@@ -73,7 +73,11 @@ export function getContexts(preset: ThemePreset) {
   const contexts: string[] = [];
 
   for (const theme of themes) {
-    contexts.push(...Object.keys(theme.contexts));
+    Object.keys(theme.contexts).forEach((contextName) => {
+      if (contexts.indexOf(contextName) === -1) {
+        contexts.push(contextName);
+      }
+    });
   }
 
   return contexts;


### PR DESCRIPTION
…theme

Needed to be able to use TypeScript for secondary themes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
