### PR TITLE
fix: Ignore overriden contexts that do not exist in the theme

### DIFF
--- a/src/__fixtures__/common.ts
+++ b/src/__fixtures__/common.ts
@@ -318,6 +318,22 @@ export const override: Override = {
   },
 };
 
+export const overrideWithRandomContext: Override = {
+  tokens: { ...override.tokens },
+  contexts: {
+    randomContext: {
+      tokens: {
+        shadow: {
+          light: 'pink',
+        },
+        buttonShadow: {
+          dark: 'green',
+        },
+      },
+    },
+  },
+};
+
 export const preset: ThemePreset = {
   theme: rootTheme,
   themeable: ['shadow', 'boxShadow', 'buttonShadow', 'lineShadow'],

--- a/src/shared/theme/__tests__/merge.test.ts
+++ b/src/shared/theme/__tests__/merge.test.ts
@@ -1,11 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { rootTheme, override } from '../../../__fixtures__/common';
+import { rootTheme, override, overrideWithRandomContext } from '../../../__fixtures__/common';
 import { merge } from '../merge';
 
 describe('merge', () => {
   test('merges theme with override and matches previous snapshot', () => {
     const out = merge(rootTheme, override);
     expect(out).toMatchSnapshot();
+  });
+  test('ignores overridden contexts that are not defined in the theme and matches previous snapshot', () => {
+    const out = merge(rootTheme, overrideWithRandomContext);
+    expect(out.contexts).not.toHaveProperty('randomContext');
   });
 });

--- a/src/shared/theme/merge.ts
+++ b/src/shared/theme/merge.ts
@@ -50,7 +50,7 @@ export function merge(theme: Theme, override: Override): Theme {
     entries(override.contexts).forEach(([contextId, context]) => {
       const resultContext = result.contexts[contextId];
 
-      if (!context) {
+      if (!context || !resultContext) {
         return;
       }
 


### PR DESCRIPTION



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
