### PR TITLE
chore: Store design tokens file name in preset

### DIFF
--- a/src/__fixtures__/common.ts
+++ b/src/__fixtures__/common.ts
@@ -340,6 +340,7 @@ export const preset: ThemePreset = {
   exposed: ['shadow', 'buttonShadow', 'boxShadow', 'lineShadow'],
   propertiesMap: createStubPropertiesMap(rootTheme),
   variablesMap: createStubVariablesMap(rootTheme),
+  designTokensFileName: 'index',
 };
 
 export const presetWithSecondaryTheme: ThemePreset = {

--- a/src/build/__tests__/public.test.ts
+++ b/src/build/__tests__/public.test.ts
@@ -94,14 +94,14 @@ test('updates preset files', async () => {
 });
 
 test('updates design tokens JS file', async () => {
-  const designTokens = await loadDesignTokens(designTokensOutputDir, preset.theme.id);
+  const designTokens = await loadDesignTokens(designTokensOutputDir, preset.designTokensFileName);
 
   expect(designTokens[token]).not.toContain(property);
   expect(designTokens[token]).toMatch(varRegex(variable, value));
 });
 
 test('updates design tokens SCSS file', async () => {
-  const designTokens = await loadFile(designTokensStylesPath(designTokensOutputDir, preset.theme.id));
+  const designTokens = await loadFile(designTokensStylesPath(designTokensOutputDir, preset.designTokensFileName));
 
   expect(designTokens).not.toContain(property);
   expect(designTokens).toMatch(varRegex(variable, value));

--- a/src/build/internal.ts
+++ b/src/build/internal.ts
@@ -89,6 +89,7 @@ export async function buildThemedComponentsInternal(params: BuildThemedComponent
     exposed,
     variablesMap,
     propertiesMap,
+    designTokensFileName,
   };
   const presetTask = skip.includes('preset') ? Promise.resolve() : createPresetFiles(preset, componentsOutputDir);
   const designTokensTask =

--- a/src/build/public.ts
+++ b/src/build/public.ts
@@ -54,7 +54,7 @@ export async function buildThemedComponents(params: BuildThemedComponentsParams)
     componentsOutputDir,
     designTokensOutputDir,
     scssDir,
-    designTokensFileName: preset.theme.id,
+    designTokensFileName: preset.designTokensFileName,
   });
 }
 

--- a/src/build/tasks/__tests__/__snapshots__/preset.test.ts.snap
+++ b/src/build/tasks/__tests__/__snapshots__/preset.test.ts.snap
@@ -201,7 +201,8 @@ exports[`renderCJSPreset matches previous snapshot 1`] = `
     \\"appear\\": \\"appear-var\\",
     \\"containerShadowBase\\": \\"containerShadowBase-var\\",
     \\"modalShadowContainer\\": \\"modalShadowContainer-var\\"
-  }
+  },
+  \\"designTokensFileName\\": \\"index\\"
 };
 "
 `;
@@ -407,7 +408,8 @@ exports[`renderPreset matches previous snapshot 1`] = `
     \\"appear\\": \\"appear-var\\",
     \\"containerShadowBase\\": \\"containerShadowBase-var\\",
     \\"modalShadowContainer\\": \\"modalShadowContainer-var\\"
-  }
+  },
+  \\"designTokensFileName\\": \\"index\\"
 };
 "
 `;

--- a/src/shared/theme/interfaces.ts
+++ b/src/shared/theme/interfaces.ts
@@ -59,4 +59,5 @@ export interface ThemePreset {
   propertiesMap: Record<Token, string>;
   /** Map between design tokens and variable names */
   variablesMap: Record<Token, string>;
+  designTokensFileName: string;
 }


### PR DESCRIPTION
The theme id was being used incorrectly to generate the design tokens filename for build-time theming. The file name should be the same as the one generated for the official build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
