### PR TITLE
chore: Add more logging to resolve token mode error handling

### DIFF
--- a/src/__fixtures__/common.ts
+++ b/src/__fixtures__/common.ts
@@ -199,6 +199,13 @@ export const themeWithNonExistingToken: Theme = {
   },
 };
 
+export const themeWithTokenWithoutModeResolution: Theme = {
+  ...emptyTheme,
+  tokens: {
+    shadow: { notMode: '{token}' },
+  },
+};
+
 export const fullResolution: FullResolution = {
   black: 'black',
   grey: 'grey',

--- a/src/shared/theme/__tests__/resolve.test.ts
+++ b/src/shared/theme/__tests__/resolve.test.ts
@@ -6,6 +6,7 @@ import {
   fullResolutionPaths,
   themesWithCircularDependencies,
   themeWithNonExistingToken,
+  themeWithTokenWithoutModeResolution,
 } from '../../../__fixtures__/common';
 import { resolveTheme, resolveThemeWithPaths } from '../resolve';
 
@@ -32,6 +33,12 @@ describe('resolve', () => {
   test('throws errors in case of non-existing token', () => {
     expect(() => resolveTheme(themeWithNonExistingToken)).toThrow(
       'Token nonExistingToken does not exist in the theme.'
+    );
+  });
+
+  test('throws errors in case of token does not have mode a resolution', () => {
+    expect(() => resolveTheme(themeWithTokenWithoutModeResolution)).toThrow(
+      `Mode resolution for token shadow does not have any mode value. modes: {"notMode":"{token}"}`
     );
   });
 });

--- a/src/shared/theme/resolve.ts
+++ b/src/shared/theme/resolve.ts
@@ -60,7 +60,9 @@ function resolveToken(theme: Theme, token: string, path: Array<string>, state?: 
 
   if (isModeValue(assignment)) {
     if (!state) {
-      throw new Error('Mode resolution needs state');
+      throw new Error(
+        `Mode resolution for token ${token} does not have any mode value. modes: ${JSON.stringify(assignment)}`
+      );
     }
     assignment = assignment[state];
   }


### PR DESCRIPTION
*Description of changes:*

the thrown error when resolving a token that doesn't have any mode value does not have data about the token and modes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
