### PR TITLE
fix: use mkdirSync and cpSync in copy

### DIFF
--- a/src/build/tasks/copy.ts
+++ b/src/build/tasks/copy.ts
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { execSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 
 export function copyAllFiles(from: string, to: string) {
   if (!existsSync(to)) {
-    execSync(`mkdir -p ${to}`, { stdio: 'inherit' });
+    mkdirSync(to, { recursive: true });
   }
   execSync(`cp -r ${from}/. ${to}`, { stdio: 'inherit' });
 }

--- a/src/build/tasks/copy.ts
+++ b/src/build/tasks/copy.ts
@@ -1,11 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { execSync } from 'child_process';
-import { existsSync, mkdirSync } from 'fs';
+import { cpSync, existsSync, mkdirSync } from 'fs';
 
 export function copyAllFiles(from: string, to: string) {
   if (!existsSync(to)) {
     mkdirSync(to, { recursive: true });
   }
-  execSync(`cp -r ${from}/. ${to}`, { stdio: 'inherit' });
+  cpSync(from, to, { recursive: true });
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Currently, buildThemedComponents on Windows does not correctly generate the destination directory. This is because on Windows, `mkdir -p` is generating a directory named `-p` instead of the destination ([see also](https://superuser.com/a/816355)).

```
A subdirectory or file -p already exists.
Error occurred while processing: -p.
node:internal/errors:867
  const err = new Error(message);
              ^

Error: Command failed: mkdir -p dist\themed\design-tokens
```

![Screenshot 2024-01-10 003151](https://github.com/cloudscape-design/theming-core/assets/19419059/8dbd325b-80f2-46b8-82e1-9b726598aa6f)


This change switches to using `fs.mkdirSync` for better compatibility on Windows.

Built `@cloudscape-design/theming-build` on my Windows machine and copied theming build artifacts to node_modules in my custom theme. Did fresh build of custom theme and did not encounter `-p` folder issue during artifact generation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ACK
