### PR TITLE
chore: Remove postcss-initial plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "merge": "^2.1.1",
         "postcss": "^8.4.31",
         "postcss-discard-empty": "^6.0.0",
-        "postcss-initial": "^4.0.1",
         "postcss-inline-svg": "^6.0.0",
         "postcss-modules": "^6.0.0",
         "prettier": "^2.7.1",
@@ -8825,14 +8824,6 @@
         "postcss": "^8.2.15"
       }
     },
-    "node_modules/postcss-initial": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
     "node_modules/postcss-inline-svg": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-inline-svg/-/postcss-inline-svg-6.0.0.tgz",
@@ -17125,12 +17116,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz",
       "integrity": "sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==",
-      "requires": {}
-    },
-    "postcss-initial": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
       "requires": {}
     },
     "postcss-inline-svg": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "merge": "^2.1.1",
     "postcss": "^8.4.31",
     "postcss-discard-empty": "^6.0.0",
-    "postcss-initial": "^4.0.1",
     "postcss-inline-svg": "^6.0.0",
     "postcss-modules": "^6.0.0",
     "prettier": "^2.7.1",

--- a/scripts/generate-package
+++ b/scripts/generate-package
@@ -25,7 +25,6 @@ const packages = [
       'lodash',
       'postcss',
       'postcss-discard-empty',
-      'postcss-initial',
       'postcss-inline-svg',
       'postcss-modules',
       'sass',

--- a/src/build/tasks/postcss/index.ts
+++ b/src/build/tasks/postcss/index.ts
@@ -4,7 +4,6 @@ import autoprefixer from 'autoprefixer';
 import path from 'path';
 import postcss from 'postcss';
 import postCSSDiscardEmpty from 'postcss-discard-empty';
-import postCSSInitial from 'postcss-initial';
 import postCSSInlineSVG from 'postcss-inline-svg';
 import postCSSModules from 'postcss-modules';
 
@@ -27,9 +26,6 @@ export const postCSSAfterAll = (input: string, filename: string) => {
     autoprefixer({
       overrideBrowserslist: browserslist,
     }),
-    // Reset only inherited properties, such as color or font-size. Do not reset own properties,
-    // like display or padding, so we could set them ourselves
-    postCSSInitial({ reset: 'inherited', replace: true }),
     postCSSIncreaseSpecificity(),
     postCSSDiscardEmpty(),
   ]).process(input, { from: filename });

--- a/typings/postcss-initial.d.ts
+++ b/typings/postcss-initial.d.ts
@@ -1,3 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-declare module 'postcss-initial';


### PR DESCRIPTION
This PR removes the `postcss-initial` plugin from theming core. This package is incompatible with our RTL initiative as it sets the `direction` attribute to `ltr` instead of `inherit`. Given the package appears to be no longer maintained, we are removing it and replacing the use of `all: initial` in our styles reset to a [manual list of properties](https://github.com/cloudscape-design/components/pull/1876).