### PR TITLE
feat: add generateThemeStylesheet API, only output override styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/builder/__tests__/actual
 node_modules
 coverage
 out
+.idea/

--- a/src/browser/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/browser/__tests__/__snapshots__/index.test.ts.snap
@@ -10,31 +10,32 @@ exports[`with baseThemeId > attaches one style node containing overrides with th
 @media not print {.dark.dark.secondary-theme:not(#\\9){
 	--shadow-css:orange;
 	--buttonShadow-css:red;
+	--boxShadow-css:black;
 	--lineShadow-css:pink;
 }}
 .secondary-theme.secondary-theme .navigation:not(#\\9){
 	--shadow-css:pink;
 	--buttonShadow-css:red;
-	--boxShadow-css:pink;
-	--lineShadow-css:red;
+	--boxShadow-css:green;
+	--lineShadow-css:pink;
 }
 .navigation.navigation.secondary-theme:not(#\\9){
 	--shadow-css:pink;
 	--buttonShadow-css:red;
-	--boxShadow-css:pink;
-	--lineShadow-css:red;
+	--boxShadow-css:green;
+	--lineShadow-css:pink;
 }
 @media not print {.dark.dark.secondary-theme .navigation:not(#\\9){
-	--shadow-css:orange;
+	--shadow-css:grey;
 	--buttonShadow-css:green;
 	--boxShadow-css:black;
-	--lineShadow-css:black;
+	--lineShadow-css:pink;
 }}
 @media not print {.dark.dark.navigation.secondary-theme:not(#\\9){
-	--shadow-css:orange;
+	--shadow-css:grey;
 	--buttonShadow-css:green;
 	--boxShadow-css:black;
-	--lineShadow-css:black;
+	--lineShadow-css:pink;
 }}"
 `;
 
@@ -48,25 +49,26 @@ exports[`with secondary theme > attaches one style node containing override 1`] 
 @media not print {.dark.dark:not(#\\9){
 	--shadow-css:orange;
 	--buttonShadow-css:red;
+	--boxShadow-css:brown;
 	--lineShadow-css:pink;
 }}
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
 	--buttonShadow-css:red;
 	--boxShadow-css:purple;
-	--lineShadow-css:red;
+	--lineShadow-css:pink;
 }
 @media not print {.dark.dark .navigation:not(#\\9){
-	--shadow-css:orange;
+	--shadow-css:brown;
 	--buttonShadow-css:green;
 	--boxShadow-css:purple;
-	--lineShadow-css:purple;
+	--lineShadow-css:pink;
 }}
 @media not print {.dark.dark.navigation:not(#\\9){
-	--shadow-css:orange;
+	--shadow-css:brown;
 	--buttonShadow-css:green;
 	--boxShadow-css:purple;
-	--lineShadow-css:purple;
+	--lineShadow-css:pink;
 }}"
 `;
 
@@ -80,25 +82,26 @@ exports[`with targetDocument > attaches one style node containing override on th
 @media not print {.dark.dark:not(#\\9){
 	--shadow-css:orange;
 	--buttonShadow-css:red;
+	--boxShadow-css:brown;
 	--lineShadow-css:pink;
 }}
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
 	--buttonShadow-css:red;
 	--boxShadow-css:purple;
-	--lineShadow-css:red;
+	--lineShadow-css:pink;
 }
 @media not print {.dark.dark .navigation:not(#\\9){
-	--shadow-css:orange;
+	--shadow-css:brown;
 	--buttonShadow-css:green;
 	--boxShadow-css:purple;
-	--lineShadow-css:purple;
+	--lineShadow-css:pink;
 }}
 @media not print {.dark.dark.navigation:not(#\\9){
-	--shadow-css:orange;
+	--shadow-css:brown;
 	--buttonShadow-css:green;
 	--boxShadow-css:purple;
-	--lineShadow-css:purple;
+	--lineShadow-css:pink;
 }}"
 `;
 
@@ -112,24 +115,25 @@ exports[`without secondary theme > attaches one style node containing override 1
 @media not print {.dark.dark:not(#\\9){
 	--shadow-css:orange;
 	--buttonShadow-css:red;
+	--boxShadow-css:brown;
 	--lineShadow-css:pink;
 }}
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
 	--buttonShadow-css:red;
 	--boxShadow-css:purple;
-	--lineShadow-css:red;
+	--lineShadow-css:pink;
 }
 @media not print {.dark.dark .navigation:not(#\\9){
-	--shadow-css:orange;
+	--shadow-css:brown;
 	--buttonShadow-css:green;
 	--boxShadow-css:purple;
-	--lineShadow-css:purple;
+	--lineShadow-css:pink;
 }}
 @media not print {.dark.dark.navigation:not(#\\9){
-	--shadow-css:orange;
+	--shadow-css:brown;
 	--buttonShadow-css:green;
 	--boxShadow-css:purple;
-	--lineShadow-css:purple;
+	--lineShadow-css:pink;
 }}"
 `;

--- a/src/browser/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/browser/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`with baseThemeId > attaches one style node containing overrides with the correct theme selector 1`] = `
+exports[`applyTheme > with baseThemeId > attaches one style node containing overrides with the correct theme selector 1`] = `
 ".secondary-theme.secondary-theme:not(#\\9){
 	--shadow-css:yellow;
 	--buttonShadow-css:red;
@@ -39,7 +39,7 @@ exports[`with baseThemeId > attaches one style node containing overrides with th
 }}"
 `;
 
-exports[`with secondary theme > attaches one style node containing override 1`] = `
+exports[`applyTheme > with secondary theme > attaches one style node containing override 1`] = `
 ":root:root{
 	--shadow-css:yellow;
 	--buttonShadow-css:red;
@@ -72,7 +72,7 @@ exports[`with secondary theme > attaches one style node containing override 1`] 
 }}"
 `;
 
-exports[`with targetDocument > attaches one style node containing override on the target document 1`] = `
+exports[`applyTheme > with targetDocument > attaches one style node containing override on the target document 1`] = `
 ":root:root{
 	--shadow-css:yellow;
 	--buttonShadow-css:red;
@@ -105,7 +105,112 @@ exports[`with targetDocument > attaches one style node containing override on th
 }}"
 `;
 
-exports[`without secondary theme > attaches one style node containing override 1`] = `
+exports[`applyTheme > without secondary theme > attaches one style node containing override 1`] = `
+":root:root{
+	--shadow-css:yellow;
+	--buttonShadow-css:red;
+	--boxShadow-css:green;
+	--lineShadow-css:pink;
+}
+@media not print {.dark.dark:not(#\\9){
+	--shadow-css:orange;
+	--buttonShadow-css:red;
+	--boxShadow-css:brown;
+	--lineShadow-css:pink;
+}}
+.navigation.navigation:not(#\\9){
+	--shadow-css:pink;
+	--buttonShadow-css:red;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
+}
+@media not print {.dark.dark .navigation:not(#\\9){
+	--shadow-css:brown;
+	--buttonShadow-css:green;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
+}}
+@media not print {.dark.dark.navigation:not(#\\9){
+	--shadow-css:brown;
+	--buttonShadow-css:green;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
+}}"
+`;
+
+exports[`generateThemeStylesheet > with baseThemeId > creates override styles 1`] = `
+".secondary-theme.secondary-theme:not(#\\9){
+	--shadow-css:yellow;
+	--buttonShadow-css:red;
+	--boxShadow-css:green;
+	--lineShadow-css:pink;
+}
+@media not print {.dark.dark.secondary-theme:not(#\\9){
+	--shadow-css:orange;
+	--buttonShadow-css:red;
+	--boxShadow-css:black;
+	--lineShadow-css:pink;
+}}
+.secondary-theme.secondary-theme .navigation:not(#\\9){
+	--shadow-css:pink;
+	--buttonShadow-css:red;
+	--boxShadow-css:green;
+	--lineShadow-css:pink;
+}
+.navigation.navigation.secondary-theme:not(#\\9){
+	--shadow-css:pink;
+	--buttonShadow-css:red;
+	--boxShadow-css:green;
+	--lineShadow-css:pink;
+}
+@media not print {.dark.dark.secondary-theme .navigation:not(#\\9){
+	--shadow-css:grey;
+	--buttonShadow-css:green;
+	--boxShadow-css:black;
+	--lineShadow-css:pink;
+}}
+@media not print {.dark.dark.navigation.secondary-theme:not(#\\9){
+	--shadow-css:grey;
+	--buttonShadow-css:green;
+	--boxShadow-css:black;
+	--lineShadow-css:pink;
+}}"
+`;
+
+exports[`generateThemeStylesheet > with secondary theme > creates override styles 1`] = `
+":root:root{
+	--shadow-css:yellow;
+	--buttonShadow-css:red;
+	--boxShadow-css:green;
+	--lineShadow-css:pink;
+}
+@media not print {.dark.dark:not(#\\9){
+	--shadow-css:orange;
+	--buttonShadow-css:red;
+	--boxShadow-css:brown;
+	--lineShadow-css:pink;
+}}
+.navigation.navigation:not(#\\9){
+	--shadow-css:pink;
+	--buttonShadow-css:red;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
+}
+@media not print {.dark.dark .navigation:not(#\\9){
+	--shadow-css:brown;
+	--buttonShadow-css:green;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
+}}
+@media not print {.dark.dark.navigation:not(#\\9){
+	--shadow-css:brown;
+	--buttonShadow-css:green;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
+}}"
+`;
+
+exports[`generateThemeStylesheet > without secondary theme > creates override styles 1`] = `
 ":root:root{
 	--shadow-css:yellow;
 	--buttonShadow-css:red;

--- a/src/browser/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/browser/__tests__/__snapshots__/index.test.ts.snap
@@ -53,20 +53,20 @@ exports[`with secondary theme > attaches one style node containing override 1`] 
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
 	--buttonShadow-css:red;
-	--boxShadow-css:pink;
+	--boxShadow-css:purple;
 	--lineShadow-css:red;
 }
 @media not print {.dark.dark .navigation:not(#\\9){
 	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:brown;
-	--lineShadow-css:brown;
+	--boxShadow-css:purple;
+	--lineShadow-css:purple;
 }}
 @media not print {.dark.dark.navigation:not(#\\9){
 	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:brown;
-	--lineShadow-css:brown;
+	--boxShadow-css:purple;
+	--lineShadow-css:purple;
 }}"
 `;
 
@@ -85,20 +85,20 @@ exports[`with targetDocument > attaches one style node containing override on th
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
 	--buttonShadow-css:red;
-	--boxShadow-css:pink;
+	--boxShadow-css:purple;
 	--lineShadow-css:red;
 }
 @media not print {.dark.dark .navigation:not(#\\9){
 	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:brown;
-	--lineShadow-css:brown;
+	--boxShadow-css:purple;
+	--lineShadow-css:purple;
 }}
 @media not print {.dark.dark.navigation:not(#\\9){
 	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:brown;
-	--lineShadow-css:brown;
+	--boxShadow-css:purple;
+	--lineShadow-css:purple;
 }}"
 `;
 
@@ -117,19 +117,19 @@ exports[`without secondary theme > attaches one style node containing override 1
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
 	--buttonShadow-css:red;
-	--boxShadow-css:pink;
+	--boxShadow-css:purple;
 	--lineShadow-css:red;
 }
 @media not print {.dark.dark .navigation:not(#\\9){
 	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:brown;
-	--lineShadow-css:brown;
+	--boxShadow-css:purple;
+	--lineShadow-css:purple;
 }}
 @media not print {.dark.dark.navigation:not(#\\9){
 	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:brown;
-	--lineShadow-css:brown;
+	--boxShadow-css:purple;
+	--lineShadow-css:purple;
 }}"
 `;

--- a/src/browser/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/browser/__tests__/__snapshots__/index.test.ts.snap
@@ -2,633 +2,134 @@
 
 exports[`with baseThemeId > attaches one style node containing overrides with the correct theme selector 1`] = `
 ".secondary-theme.secondary-theme:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
 	--shadow-css:yellow;
 	--buttonShadow-css:red;
 	--boxShadow-css:green;
 	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:3px;
-	--appear-css:20ms;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact.secondary-theme:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
 }
 @media not print {.dark.dark.secondary-theme:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
 	--shadow-css:orange;
 	--buttonShadow-css:red;
-	--boxShadow-css:black;
 	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
 }}
-.disabled-motion.disabled-motion.secondary-theme:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
 .secondary-theme.secondary-theme .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
 	--shadow-css:pink;
 	--buttonShadow-css:red;
-	--boxShadow-css:green;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:3px;
-	--appear-css:20ms;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
+	--boxShadow-css:pink;
+	--lineShadow-css:red;
 }
 .navigation.navigation.secondary-theme:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
 	--shadow-css:pink;
 	--buttonShadow-css:red;
-	--boxShadow-css:green;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:3px;
-	--appear-css:20ms;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact.secondary-theme .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact.navigation.secondary-theme:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
+	--boxShadow-css:pink;
+	--lineShadow-css:red;
 }
 @media not print {.dark.dark.secondary-theme .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
-	--shadow-css:grey;
+	--shadow-css:orange;
 	--buttonShadow-css:green;
 	--boxShadow-css:black;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
+	--lineShadow-css:black;
 }}
 @media not print {.dark.dark.navigation.secondary-theme:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
-	--shadow-css:grey;
+	--shadow-css:orange;
 	--buttonShadow-css:green;
 	--boxShadow-css:black;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}}
-.disabled-motion.disabled-motion.secondary-theme .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.disabled-motion.disabled-motion.navigation.secondary-theme:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:purple;
-	--grey-css:grey;
-	--brown-css:black;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}"
+	--lineShadow-css:black;
+}}"
 `;
 
 exports[`with secondary theme > attaches one style node containing override 1`] = `
 ":root:root{
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
 	--shadow-css:yellow;
 	--buttonShadow-css:red;
 	--boxShadow-css:green;
 	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:3px;
-	--appear-css:20ms;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
 }
 @media not print {.dark.dark:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
 	--shadow-css:orange;
 	--buttonShadow-css:red;
-	--boxShadow-css:brown;
 	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
 }}
-.disabled-motion.disabled-motion:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
 .navigation.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
 	--shadow-css:pink;
 	--buttonShadow-css:red;
-	--boxShadow-css:purple;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:3px;
-	--appear-css:20ms;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
+	--boxShadow-css:pink;
+	--lineShadow-css:red;
 }
 @media not print {.dark.dark .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--shadow-css:brown;
+	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:purple;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
+	--boxShadow-css:brown;
+	--lineShadow-css:brown;
 }}
 @media not print {.dark.dark.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--shadow-css:brown;
+	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:purple;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}}
-.disabled-motion.disabled-motion .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.disabled-motion.disabled-motion.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}"
+	--boxShadow-css:brown;
+	--lineShadow-css:brown;
+}}"
 `;
 
 exports[`with targetDocument > attaches one style node containing override on the target document 1`] = `
 ":root:root{
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
 	--shadow-css:yellow;
 	--buttonShadow-css:red;
 	--boxShadow-css:green;
 	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:3px;
-	--appear-css:20ms;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
 }
 @media not print {.dark.dark:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
 	--shadow-css:orange;
 	--buttonShadow-css:red;
-	--boxShadow-css:brown;
 	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
 }}
-.disabled-motion.disabled-motion:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
 .navigation.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
 	--shadow-css:pink;
 	--buttonShadow-css:red;
-	--boxShadow-css:purple;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:3px;
-	--appear-css:20ms;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
+	--boxShadow-css:pink;
+	--lineShadow-css:red;
 }
 @media not print {.dark.dark .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--shadow-css:brown;
+	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:purple;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
+	--boxShadow-css:brown;
+	--lineShadow-css:brown;
 }}
 @media not print {.dark.dark.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--shadow-css:brown;
+	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:purple;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}}
-.disabled-motion.disabled-motion .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.disabled-motion.disabled-motion.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}"
+	--boxShadow-css:brown;
+	--lineShadow-css:brown;
+}}"
 `;
 
 exports[`without secondary theme > attaches one style node containing override 1`] = `
 ":root:root{
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
 	--shadow-css:yellow;
 	--buttonShadow-css:red;
 	--boxShadow-css:green;
 	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:3px;
-	--appear-css:20ms;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
 }
 @media not print {.dark.dark:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
 	--shadow-css:orange;
 	--buttonShadow-css:red;
-	--boxShadow-css:brown;
 	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
 }}
-.disabled-motion.disabled-motion:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
 .navigation.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
 	--shadow-css:pink;
 	--buttonShadow-css:red;
-	--boxShadow-css:purple;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:3px;
-	--appear-css:20ms;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.compact.compact.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--scaledSize-css:1px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
+	--boxShadow-css:pink;
+	--lineShadow-css:red;
 }
 @media not print {.dark.dark .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--shadow-css:brown;
+	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:purple;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
+	--boxShadow-css:brown;
+	--lineShadow-css:brown;
 }}
 @media not print {.dark.dark.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--shadow-css:brown;
+	--shadow-css:orange;
 	--buttonShadow-css:green;
-	--boxShadow-css:purple;
-	--lineShadow-css:pink;
-	--small-css:1px;
-	--medium-css:3px;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}}
-.disabled-motion.disabled-motion .navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}
-.disabled-motion.disabled-motion.navigation:not(#\\9){
-	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
-	--fontFamilyBody-css:"Helvetica Neue", Arial, sans-serif;
-	--black-css:black;
-	--grey-css:grey;
-	--brown-css:brown;
-	--small-css:1px;
-	--medium-css:3px;
-	--appear-css:0;
-	--containerShadowBase-css:2px 3px orange, -1px 0 8px olive;
-	--modalShadowContainer-css:2px 3px orange, -1px 0 8px olive;
-}"
+	--boxShadow-css:brown;
+	--lineShadow-css:brown;
+}}"
 `;

--- a/src/browser/__tests__/index.test.ts
+++ b/src/browser/__tests__/index.test.ts
@@ -2,94 +2,128 @@
 // SPDX-License-Identifier: Apache-2.0
 import { afterEach, describe, test, expect } from 'vitest';
 import { preset, presetWithSecondaryTheme, override } from '../../__fixtures__/common';
-import { applyTheme } from '../index';
-
-afterEach(() => {
-  allStyleNodes().forEach((tag) => tag.remove());
-});
-
-describe('without secondary theme', () => {
-  test('attaches one style node containing override', () => {
-    applyTheme({ override, preset });
-
-    const styleNodes = allStyleNodes();
-
-    expect(styleNodes).toHaveLength(1);
-    const themeNode = styleNodes[0];
-
-    expect(themeNode.innerHTML).toMatchSnapshot();
-  });
-
-  test('removes style node on reset', () => {
-    const { reset } = applyTheme({ override, preset });
-
-    reset();
-
-    expect(allStyleNodes()).toHaveLength(0);
-  });
-});
-
-describe('with secondary theme', () => {
-  test('attaches one style node containing override', () => {
-    applyTheme({ override, preset: presetWithSecondaryTheme });
-
-    const styleNodes = allStyleNodes();
-
-    expect(styleNodes).toHaveLength(1);
-    const themeNode = styleNodes[0];
-
-    expect(themeNode.innerHTML).toMatchSnapshot();
-  });
-
-  test('removes style node on reset', () => {
-    const { reset } = applyTheme({ override, preset: presetWithSecondaryTheme });
-
-    reset();
-
-    expect(allStyleNodes()).toHaveLength(0);
-  });
-});
-
-describe('with baseThemeId', () => {
-  test('attaches one style node containing overrides with the correct theme selector', () => {
-    applyTheme({ override, preset: presetWithSecondaryTheme, baseThemeId: 'secondary' });
-
-    const styleNodes = allStyleNodes();
-
-    expect(styleNodes).toHaveLength(1);
-    const themeNode = styleNodes[0];
-
-    expect(themeNode.innerHTML).toMatchSnapshot();
-  });
-
-  test('throws error if baseThemeId is not available', () => {
-    expect(() => applyTheme({ override, preset: presetWithSecondaryTheme, baseThemeId: 'invalid' })).toThrow(
-      `Specified baseThemeId 'invalid' is not available. Available values are 'root', 'secondary'.`
-    );
-  });
-});
-
-describe('with targetDocument', () => {
-  test('attaches one style node containing override on the target document', () => {
-    const targetDocument = document.implementation.createHTMLDocument();
-    applyTheme({ override, preset, targetDocument });
-
-    const styleNodes = allStyleNodes(targetDocument);
-
-    expect(styleNodes).toHaveLength(1);
-    const themeNode = styleNodes[0];
-
-    expect(themeNode.innerHTML).toMatchSnapshot();
-  });
-
-  test('removes style node on reset on the target document', () => {
-    const targetDocument = document.implementation.createHTMLDocument();
-    const { reset } = applyTheme({ override, preset, targetDocument });
-
-    reset();
-
-    expect(allStyleNodes(targetDocument)).toHaveLength(0);
-  });
-});
+import { applyTheme, generateThemeStylesheet } from '../index';
 
 const allStyleNodes = (targetDocument: Document = document) => targetDocument.head.querySelectorAll('style');
+
+describe('applyTheme', () => {
+  afterEach(() => {
+    allStyleNodes().forEach((tag) => tag.remove());
+  });
+
+  describe('without secondary theme', () => {
+    test('attaches one style node containing override', () => {
+      applyTheme({ override, preset });
+
+      const styleNodes = allStyleNodes();
+
+      expect(styleNodes).toHaveLength(1);
+      const themeNode = styleNodes[0];
+
+      expect(themeNode.innerHTML).toMatchSnapshot();
+    });
+
+    test('removes style node on reset', () => {
+      const { reset } = applyTheme({ override, preset });
+
+      reset();
+
+      expect(allStyleNodes()).toHaveLength(0);
+    });
+  });
+
+  describe('with secondary theme', () => {
+    test('attaches one style node containing override', () => {
+      applyTheme({ override, preset: presetWithSecondaryTheme });
+
+      const styleNodes = allStyleNodes();
+
+      expect(styleNodes).toHaveLength(1);
+      const themeNode = styleNodes[0];
+
+      expect(themeNode.innerHTML).toMatchSnapshot();
+    });
+
+    test('removes style node on reset', () => {
+      const { reset } = applyTheme({ override, preset: presetWithSecondaryTheme });
+
+      reset();
+
+      expect(allStyleNodes()).toHaveLength(0);
+    });
+  });
+
+  describe('with baseThemeId', () => {
+    test('attaches one style node containing overrides with the correct theme selector', () => {
+      applyTheme({ override, preset: presetWithSecondaryTheme, baseThemeId: 'secondary' });
+
+      const styleNodes = allStyleNodes();
+
+      expect(styleNodes).toHaveLength(1);
+      const themeNode = styleNodes[0];
+
+      expect(themeNode.innerHTML).toMatchSnapshot();
+    });
+
+    test('throws error if baseThemeId is not available', () => {
+      expect(() => applyTheme({ override, preset: presetWithSecondaryTheme, baseThemeId: 'invalid' })).toThrow(
+        `Specified baseThemeId 'invalid' is not available. Available values are 'root', 'secondary'.`
+      );
+    });
+  });
+
+  describe('with targetDocument', () => {
+    test('attaches one style node containing override on the target document', () => {
+      const targetDocument = document.implementation.createHTMLDocument();
+      applyTheme({ override, preset, targetDocument });
+
+      const styleNodes = allStyleNodes(targetDocument);
+
+      expect(styleNodes).toHaveLength(1);
+      const themeNode = styleNodes[0];
+
+      expect(themeNode.innerHTML).toMatchSnapshot();
+    });
+
+    test('removes style node on reset on the target document', () => {
+      const targetDocument = document.implementation.createHTMLDocument();
+      const { reset } = applyTheme({ override, preset, targetDocument });
+
+      reset();
+
+      expect(allStyleNodes(targetDocument)).toHaveLength(0);
+    });
+  });
+});
+
+describe('generateThemeStylesheet', () => {
+  describe('without secondary theme', () => {
+    test('creates override styles', () => {
+      const styles = generateThemeStylesheet({ override, preset });
+
+      expect(styles).toMatchSnapshot();
+    });
+  });
+
+  describe('with secondary theme', () => {
+    test('creates override styles', () => {
+      const styles = generateThemeStylesheet({ override, preset: presetWithSecondaryTheme });
+
+      expect(styles).toMatchSnapshot();
+    });
+  });
+
+  describe('with baseThemeId', () => {
+    test('creates override styles', () => {
+      const styles = generateThemeStylesheet({ override, preset: presetWithSecondaryTheme, baseThemeId: 'secondary' });
+
+      expect(styles).toMatchSnapshot();
+    });
+
+    test('throws error if baseThemeId is not available', () => {
+      expect(() =>
+        generateThemeStylesheet({ override, preset: presetWithSecondaryTheme, baseThemeId: 'invalid' })
+      ).toThrow(`Specified baseThemeId 'invalid' is not available. Available values are 'root', 'secondary'.`);
+    });
+  });
+});

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -6,6 +6,30 @@ import { getNonce, createStyleNode, appendStyleNode } from './dom';
 import { createMultiThemeCustomizer } from '../shared/declaration/customizer';
 import { getContexts, getThemeFromPreset } from '../shared/theme/validate';
 
+export interface GenerateThemeStylesheetParams {
+  override: Override;
+  preset: ThemePreset;
+  baseThemeId?: string;
+  targetDocument?: Document;
+}
+
+export function generateThemeStylesheet(params: GenerateThemeStylesheetParams): string {
+  const { override, preset, baseThemeId } = params;
+
+  const availableContexts = getContexts(preset);
+
+  const validated = validateOverride(override, preset.themeable, availableContexts);
+
+  const theme = getThemeFromPreset(preset, baseThemeId);
+
+  return createOverrideDeclarations(
+    theme,
+    validated,
+    preset.propertiesMap,
+    createMultiThemeCustomizer(preset.theme.selector)
+  );
+}
+
 export interface ApplyThemeParams {
   override: Override;
   preset: ThemePreset;
@@ -18,20 +42,8 @@ export interface ApplyThemeResult {
 }
 
 export function applyTheme(params: ApplyThemeParams): ApplyThemeResult {
-  const { override, preset, baseThemeId, targetDocument } = params;
-
-  const availableContexts = getContexts(preset);
-
-  const validated = validateOverride(override, preset.themeable, availableContexts);
-
-  const theme = getThemeFromPreset(preset, baseThemeId);
-
-  const content = createOverrideDeclarations(
-    theme,
-    validated,
-    preset.propertiesMap,
-    createMultiThemeCustomizer(preset.theme.selector)
-  );
+  const { targetDocument } = params;
+  const content = generateThemeStylesheet(params);
   const nonce = getNonce(targetDocument);
   const styleNode = createStyleNode(content, nonce);
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -10,16 +10,12 @@ export interface GenerateThemeStylesheetParams {
   override: Override;
   preset: ThemePreset;
   baseThemeId?: string;
-  targetDocument?: Document;
 }
 
 export function generateThemeStylesheet(params: GenerateThemeStylesheetParams): string {
   const { override, preset, baseThemeId } = params;
-
   const availableContexts = getContexts(preset);
-
   const validated = validateOverride(override, preset.themeable, availableContexts);
-
   const theme = getThemeFromPreset(preset, baseThemeId);
 
   return createOverrideDeclarations(

--- a/src/shared/declaration/__integ__/browser.test.ts
+++ b/src/shared/declaration/__integ__/browser.test.ts
@@ -136,10 +136,8 @@ test(
       scaledSize: '2px',
       shadow: 'black',
     });
-    // base styles contain overrides for this context, but in this test
-    // they are not applied because only the override styles are rendered
     expect(resolutionContext).toEqual({
-      boxShadow: 'black',
+      boxShadow: 'purple',
       buttonShadow: 'black',
       lineShadow: 'black',
       medium: '2px',

--- a/src/shared/declaration/index.ts
+++ b/src/shared/declaration/index.ts
@@ -22,7 +22,7 @@ export function createOverrideDeclarations(
     context.tokens = {};
   });
   // create theme containing only modified tokens
-  const merged = mergeInPlace(emptyBase, override);
+  const merged = mergeInPlace(emptyBase, override, base);
   const ruleCreator = new RuleCreator(new Selector(selectorCustomizer), new AllPropertyRegistry(propertiesMap));
   const stylesheetCreator = new SingleThemeCreator(merged, ruleCreator, base);
   const stylesheet = stylesheetCreator.create();

--- a/src/shared/declaration/index.ts
+++ b/src/shared/declaration/index.ts
@@ -27,6 +27,7 @@ function createMinimalTheme(base: Theme, override: Override): Theme {
       delete minimalTheme.tokens[key];
     }
   });
+
   return mergeInPlace(minimalTheme, override);
 }
 

--- a/src/shared/declaration/single.ts
+++ b/src/shared/declaration/single.ts
@@ -49,7 +49,7 @@ export class SingleThemeCreator extends AbstractCreator implements StylesheetCre
 
     SingleThemeCreator.forEachContext(this.theme, (context) => {
       const contextResolution = reduce(
-        resolveContext(this.theme, context, this.baseTheme),
+        resolveContext(this.theme, context, this.baseTheme, this.resolution),
         this.theme,
         defaultsReducer(),
         this.baseTheme
@@ -69,7 +69,7 @@ export class SingleThemeCreator extends AbstractCreator implements StylesheetCre
 
     SingleThemeCreator.forEachContextWithinOptionalModeState(this.theme, (context, mode, state) => {
       const contextResolution = reduce(
-        resolveContext(this.theme, context, this.baseTheme),
+        resolveContext(this.theme, context, this.baseTheme, this.resolution),
         this.theme,
         modeReducer(mode, state),
         this.baseTheme

--- a/src/shared/theme/index.ts
+++ b/src/shared/theme/index.ts
@@ -26,4 +26,4 @@ export {
   FullResolutionPaths,
 } from './resolve';
 export { validateOverride } from './validate';
-export { merge } from './merge';
+export { merge, mergeInPlace } from './merge';

--- a/src/shared/theme/merge.ts
+++ b/src/shared/theme/merge.ts
@@ -8,7 +8,7 @@ import { getMode, isModeValue, isReference, isValue } from './utils';
  * This function applies all tokens from the override to the theme.
  * It returns the resulting theme. The original theme object is modified.
  */
-export function mergeInPlace(theme: Theme, override: Override): Theme {
+export function mergeInPlace(theme: Theme, override: Override, baseTheme?: Theme): Theme {
   function withTokenApplied(
     originalValue: Assignment,
     token: string,
@@ -36,7 +36,7 @@ export function mergeInPlace(theme: Theme, override: Override): Theme {
 
   // Merge root-level tokens into the theme
   entries(override.tokens).forEach(([token, update]) => {
-    const newValue = withTokenApplied(theme.tokens[token], token, update);
+    const newValue = withTokenApplied(theme.tokens[token] ?? baseTheme?.tokens[token], token, update);
     if (newValue) {
       theme.tokens[token] = newValue;
     }
@@ -52,7 +52,11 @@ export function mergeInPlace(theme: Theme, override: Override): Theme {
       }
 
       entries(context.tokens).forEach(([token, update]) => {
-        const originalValue = themeContext.tokens[token] ?? theme.tokens[token];
+        const originalValue =
+          themeContext.tokens[token] ??
+          baseTheme?.contexts[contextId].tokens[token] ??
+          theme.tokens[token] ??
+          baseTheme?.tokens[token];
         const newValue = withTokenApplied(originalValue, token, update);
         if (newValue) {
           theme.contexts[contextId].tokens[token] = newValue;

--- a/src/shared/theme/merge.ts
+++ b/src/shared/theme/merge.ts
@@ -8,7 +8,7 @@ import { getMode, isModeValue, isReference, isValue } from './utils';
  * This function applies all tokens from the override to the theme.
  * It returns the resulting theme. The original theme object is modified.
  */
-export function mergeInPlace(theme: Theme, override: Override, baseTheme?: Theme): Theme {
+export function mergeInPlace(theme: Theme, override: Override): Theme {
   function withTokenApplied(
     originalValue: Assignment,
     token: string,
@@ -36,7 +36,7 @@ export function mergeInPlace(theme: Theme, override: Override, baseTheme?: Theme
 
   // Merge root-level tokens into the theme
   entries(override.tokens).forEach(([token, update]) => {
-    const newValue = withTokenApplied(theme.tokens[token] ?? baseTheme?.tokens[token], token, update);
+    const newValue = withTokenApplied(theme.tokens[token], token, update);
     if (newValue) {
       theme.tokens[token] = newValue;
     }
@@ -52,11 +52,7 @@ export function mergeInPlace(theme: Theme, override: Override, baseTheme?: Theme
       }
 
       entries(context.tokens).forEach(([token, update]) => {
-        const originalValue =
-          themeContext.tokens[token] ??
-          baseTheme?.contexts[contextId].tokens[token] ??
-          theme.tokens[token] ??
-          baseTheme?.tokens[token];
+        const originalValue = themeContext.tokens[token] ?? theme.tokens[token];
         const newValue = withTokenApplied(originalValue, token, update);
         if (newValue) {
           theme.contexts[contextId].tokens[token] = newValue;

--- a/src/shared/theme/resolve.ts
+++ b/src/shared/theme/resolve.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Context, Mode } from '.';
 import { cloneDeep, values } from '../utils';
-import { Assignment, Theme, Value } from './interfaces';
+import { Theme, Value } from './interfaces';
 import { areAssignmentsEqual, getDefaultState, getMode, getReference, isModeValue, isReference } from './utils';
 
 export type ModeTokenResolution = Record<string, Value>;
@@ -126,7 +126,7 @@ export function resolveContext(
   tmp.tokens = {
     ...Object.keys(themeResolution).reduce((acc, key) => {
       const shouldSkipReset =
-        !(key in baseContext.tokens) ||
+        (!(key in baseContext.tokens) && !(key in tmp.tokens)) ||
         areAssignmentsEqual(
           baseContext.tokens[key],
           tmp.tokens[key] ?? baseTheme.tokens[key] // resolved key may not be in override theme
@@ -136,7 +136,7 @@ export function resolveContext(
         ? acc
         : {
             ...acc,
-            [key]: baseContext.tokens[key],
+            [key]: baseContext.tokens[key] ?? tmp.tokens[key] ?? baseTheme.tokens[key],
           };
     }, {}),
     ...context.tokens,

--- a/src/shared/theme/resolve.ts
+++ b/src/shared/theme/resolve.ts
@@ -116,7 +116,7 @@ export function resolveContext(
    * The precedence of tokens as specified by the API from highest to lowest is:
    * [override theme context] > [base theme context] > [override theme] > [base theme]
    *
-   * The CSS precedence as defined in the generated CSS is generally:
+   * The precedence of tokens as defined in the generated CSS is generally:
    * [override theme context] > [override theme] > [base theme context] > [base theme]
    *
    * To counteract this we can re-baseline the override context using all keys used

--- a/src/shared/theme/utils.ts
+++ b/src/shared/theme/utils.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { DefaultState, OptionalState, Theme } from './interfaces';
+import { Assignment, DefaultState, OptionalState, Theme } from './interfaces';
 import { Value, Reference, ModeValue, Mode } from './interfaces';
 
 export function isValue(val: unknown): val is Value {
@@ -16,6 +16,16 @@ export function isModeValue(val: unknown): val is ModeValue {
     typeof val === 'object' &&
     val !== null &&
     !Object.keys(val).some((state) => !(isValue((val as ModeValue)[state]) || isReference((val as ModeValue)[state])))
+  );
+}
+
+export function areAssignmentsEqual(valueA: Assignment, valueB: Assignment): boolean {
+  return (
+    valueA === valueB ||
+    (typeof valueA === 'object' &&
+      typeof valueB == 'object' &&
+      Object.keys(valueA).length === Object.keys(valueB).length &&
+      Object.keys(valueA).every((key) => valueA[key] === valueB[key]))
   );
 }
 


### PR DESCRIPTION
This change adds the `generateThemeStylesheet` API for runtime theming. The currently available `applyTheme` API internally generates theme CSS and creates a `<style />` tag and inserts it. This `generateThemeStylesheet` API only generates the stylesheet content. `applyTheme` is an expensive call -- with this new API the styles can be generated server-side and cached (regardless of CSR/SSR).

As part of this contribution, I'm making an optimization to the generation of theme styles. Currently css is generated for every cloudscape design token (rather than just those that were overridden for theming) resulting in 900KB+ (90KB gzipped, ~20K lines) of mostly duplicate css. Additionally, the call time for `applyTheme` is relatively high. In our fargate container, this call takes ~800ms - 1000ms, and on my local machine takes ~150ms in the browser.

I've updated runtime theming to only generate css needed for the specified overrides. My assumption is that everyone using runtime theming would have base styles, but if we can't make this assumption I can instead expose this behavior as an opt-in flag.

For my particular use case (using ~45 design tokens), this results in override CSS of ~90KB (4KB gzipped, ~1500 lines). The call time is also reduced -- though not in proportion to the css size because iterating over all design tokens in the base theme is still required. In our fargate container, the call time is now ~100ms - 200ms, and is ~75ms on my local machine.

Will cut a PR to the `components` repo to expose `generateThemeStylesheet` once this is merged

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
