### PR TITLE
chore: Support @cloudscape-design npm-style imports in sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babel/plugin-transform-modules-commonjs": "^7.18.6",
         "@cloudscape-design/browser-test-tools": "^3.0.2",
+        "@cloudscape-design/component-toolkit": "^1.0.0-beta.53",
         "@tsconfig/node16": "^1.0.3",
         "@types/loader-utils": "^2.0.3",
         "@types/lodash": "^4.14.183",
@@ -931,6 +932,15 @@
         "webdriverio": "^7.25.2"
       }
     },
+    "node_modules/@cloudscape-design/component-toolkit": {
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.53.tgz",
+      "integrity": "sha512-FNZnsdz2YQP9kqhvUIDRpT1Oc//NXDxEMCFQHLY9jdu19eXhZZfJBF4wRFOIIlhXtHq2Ae7pxZ9Z0VJJnUOk7g==",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.3.1",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
@@ -1465,6 +1475,11 @@
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+    },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -9585,6 +9600,15 @@
         "webdriverio": "^7.25.2"
       }
     },
+    "@cloudscape-design/component-toolkit": {
+      "version": "1.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@cloudscape-design/component-toolkit/-/component-toolkit-1.0.0-beta.53.tgz",
+      "integrity": "sha512-FNZnsdz2YQP9kqhvUIDRpT1Oc//NXDxEMCFQHLY9jdu19eXhZZfJBF4wRFOIIlhXtHq2Ae7pxZ9Z0VJJnUOk7g==",
+      "requires": {
+        "@juggle/resize-observer": "^3.3.1",
+        "tslib": "^2.3.1"
+      }
+    },
     "@esbuild/aix-ppc64": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
@@ -9858,6 +9882,11 @@
           "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         }
       }
+    },
+    "@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.18.6",
     "@cloudscape-design/browser-test-tools": "^3.0.2",
+    "@cloudscape-design/component-toolkit": "^1.0.0-beta.53",
     "@tsconfig/node16": "^1.0.3",
     "@types/loader-utils": "^2.0.3",
     "@types/lodash": "^4.14.183",

--- a/src/build/__tests__/__fixtures__/scss-advanced/button/styles.scss
+++ b/src/build/__tests__/__fixtures__/scss-advanced/button/styles.scss
@@ -3,8 +3,9 @@
 @use 'sass:string';
 @use 'awsui:resolved-tokens' as resolved-tokens;
 @use '../internal/styles/tokens' as awsui;
+@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;
 
-$tokens: map.get(list.nth(resolved-tokens.$resolved-tokens , 1), 'tokens');
+$tokens: map.get(list.nth(resolved-tokens.$resolved-tokens, 1), 'tokens');
 $colorBackgroundButtonPrimaryDefault: map.get($tokens, 'colorBackgroundButtonPrimaryDefault');
 $elementColor: string.unquote(map.get($colorBackgroundButtonPrimaryDefault, 'dark'));
 
@@ -21,4 +22,3 @@ $elementColor: string.unquote(map.get($colorBackgroundButtonPrimaryDefault, 'dar
 .caret {
   background: svg-load('./assets/icon.svg', stroke=black);
 }
-

--- a/src/build/tasks/style.ts
+++ b/src/build/tasks/style.ts
@@ -6,6 +6,7 @@ import { postCSSForEach, postCSSAfterAll, scopedFileExt } from './postcss';
 import path from 'path';
 import fs from 'fs';
 import { promisify } from 'util';
+import { pathToFileURL } from 'url';
 
 export interface InlineStylesheet {
   url: string;
@@ -45,6 +46,15 @@ function createImporter(inlines: InlineStylesheet[]): sass.Importer {
   return importer;
 }
 
+const cloudscapeNpmImports = {
+  findFileUrl(url: string) {
+    if (url.startsWith('@cloudscape-design')) {
+      return new URL(`${pathToFileURL('node_modules')}/${url}`);
+    }
+    return null;
+  },
+};
+
 function createCompiler(inlines: InlineStylesheet[], outputDir: string, sassDir: string) {
   const importer = createImporter(inlines);
   return async (file: string) => {
@@ -52,7 +62,7 @@ function createCompiler(inlines: InlineStylesheet[], outputDir: string, sassDir:
 
     const sassResult = sass.compile(input, {
       style: 'expanded',
-      importers: [importer],
+      importers: [importer, cloudscapeNpmImports],
     });
     const intermediate = path.join(sassDir, rename(file, '.css'));
     const postCSSForEachResult = await postCSSForEach(sassDir, outputDir, sassResult.css, intermediate);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allow e.g. `@use '@cloudscape-design/component-toolkit/internal/focus-visible' as focus-visible;` in SASS files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
