### PR TITLE
fix: Remove internal exports from the public API

### DIFF
--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 export { buildThemedComponents, BuildThemedComponentsParams } from './public';
-export { buildThemedComponentsInternal, BuildThemedComponentsInternalParams } from './internal';
 export {
   Theme,
   ThemePreset,


### PR DESCRIPTION
*Issue #, if available:*

Follow up for this change: https://github.com/cloudscape-design/components/pull/2075.

We are fine across all our packages now: https://github.com/search?q=org%3Acloudscape-design%20buildThemedComponentsInternal&type=code

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
