### PR TITLE
feat: Allow to fail the build when sass deprecation warnings found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "postcss-inline-svg": "^6.0.0",
         "postcss-modules": "^6.0.0",
         "prettier": "^2.7.1",
-        "sass": "^1.49.0",
+        "sass": "^1.77.8",
         "string-hash": "^1.1.3",
         "tslib": "^2.4.0",
         "typescript": "^4.7.4",
@@ -7736,9 +7736,9 @@
       "peer": true
     },
     "node_modules/sass": {
-      "version": "1.63.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
-      "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -14559,9 +14559,9 @@
       "peer": true
     },
     "sass": {
-      "version": "1.63.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.6.tgz",
-      "integrity": "sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postcss-inline-svg": "^6.0.0",
     "postcss-modules": "^6.0.0",
     "prettier": "^2.7.1",
-    "sass": "^1.49.0",
+    "sass": "^1.77.8",
     "string-hash": "^1.1.3",
     "tslib": "^2.4.0",
     "typescript": "^4.7.4",

--- a/src/build/__tests__/__fixtures__/scss-only/mixed-declarations/styles.scss
+++ b/src/build/__tests__/__fixtures__/scss-only/mixed-declarations/styles.scss
@@ -1,0 +1,11 @@
+.example {
+  color: red;
+
+  a {
+    font-weight: bold;
+  }
+
+  // top level style after the nested rule to trigger this deprecation warning
+  // https://sass-lang.com/documentation/breaking-changes/mixed-decls/
+  font-weight: normal;
+}

--- a/src/build/internal.ts
+++ b/src/build/internal.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { buildStyles, InlineStylesheet } from './tasks/style';
+import { buildStyles, InlineStylesheet, BuildStylesOptions } from './tasks/style';
 import { createPresetFiles } from './tasks/preset';
 import { createInternalTokenFiles } from './tasks/internal-tokens';
 import { createPublicTokenFiles } from './tasks/public-tokens';
@@ -9,7 +9,7 @@ import { getInlineStylesheets } from './inline-stylesheets';
 import { calculatePropertiesMap } from './properties';
 import findNeededTokens from './needed-tokens';
 
-export { buildStyles, InlineStylesheet };
+export { buildStyles, InlineStylesheet, BuildStylesOptions };
 
 export type Tasks = 'preset' | 'design-tokens';
 
@@ -38,6 +38,8 @@ export interface BuildThemedComponentsInternalParams {
   descriptions?: Record<string, string>;
   /** Indicates whether to generate a JSON schema for design tokens JSON format and validate against the schema **/
   jsonSchema?: boolean;
+  /** Fail the build when SASS deprecation warning occurs **/
+  failOnDeprecations?: boolean;
 }
 /**
  * Builds themed components and optionally design tokens, if not skipped.
@@ -68,6 +70,7 @@ export async function buildThemedComponentsInternal(params: BuildThemedComponent
     skip = [],
     descriptions = {},
     jsonSchema = false,
+    failOnDeprecations,
   } = params;
 
   if (!skip.includes('design-tokens') && !designTokensOutputDir) {
@@ -83,7 +86,8 @@ export async function buildThemedComponentsInternal(params: BuildThemedComponent
   const styleTask = buildStyles(
     scssDir,
     componentsOutputDir,
-    getInlineStylesheets(primary, secondary, defaults, variablesMap, propertiesMap, neededTokens)
+    getInlineStylesheets(primary, secondary, defaults, variablesMap, propertiesMap, neededTokens),
+    { failOnDeprecations }
   );
   const internalTokensTask = createInternalTokenFiles(defaults, propertiesMap, componentsOutputDir);
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/cloudscape-design/components/issues/2571

*Description of changes:*

Detect and fail when deprecation warnings mentioned in https://github.com/cloudscape-design/components/issues/2571 are found.

Made this an opt-in flag to allow gradual migration for our existing code.

---

I explored an alternative option about stylelint rule, but this is not possible to detect this case using stylelint, because it requires actual compliation of the sass code, to see where the issue happens


---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
