### PR TITLE
feat: add stack info when printing deprecation warning

### DIFF
--- a/src/build/tasks/style.ts
+++ b/src/build/tasks/style.ts
@@ -73,10 +73,11 @@ function createCompiler(inlines: InlineStylesheet[], outputDir: string, sassDir:
     const sassResult = sass.compile(input, {
       logger: {
         warn(message, meta) {
+          const fullMessage = [message, meta.stack].join('\n');
           if (meta.deprecation && options.failOnDeprecations) {
-            deprecations.push(message);
+            deprecations.push(fullMessage);
           } else {
-            console.warn(message);
+            console.warn(fullMessage);
           }
         },
       },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Print stack information with a deprecation warning. This will help to find their locations and fix


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
