### PR TITLE
chore: add size value schema for token validation

### DIFF
--- a/src/build/tasks/__tests__/theme-json-schema.test.ts
+++ b/src/build/tasks/__tests__/theme-json-schema.test.ts
@@ -295,12 +295,18 @@ describe('validateJson', () => {
               compact: '50%',
             },
           },
+          'size-auto': {
+            $value: {
+              comfortable: 'auto',
+              compact: 'auto',
+            },
+          },
         }),
       ).toBe(true);
     });
 
     test('rejects invalid formats', () => {
-      ['100 px', '20ps', '100 %', '100px a', 'auto', 'none', 'inherit'].forEach((invalidValue) => {
+      ['100 px', '20ps', '100 %', '100px a', 'none', 'inherit'].forEach((invalidValue) => {
         expect(() =>
           validateTokens({
             'size-button': {
@@ -311,7 +317,7 @@ describe('validateJson', () => {
             },
           }),
         ).toThrowError(
-          'Tokens validation error: instance.tokens.size-button.$value.comfortable does not match pattern "^\\\\d+(\\\\.\\\\d+)?(px|rem|em|%)$"',
+          'Tokens validation error: instance.tokens.size-button.$value.comfortable does not match pattern "^(auto|\\\\d+(\\\\.\\\\d+)?(px|rem|em|%))$"',
         );
       });
     });

--- a/src/build/tasks/__tests__/theme-json-schema.test.ts
+++ b/src/build/tasks/__tests__/theme-json-schema.test.ts
@@ -269,6 +269,54 @@ describe('validateJson', () => {
     });
   });
 
+  describe('size', () => {
+    test('should have comfortable and compact values defined', () => {
+      expect(() => {
+        validateTokens({
+          'size-button': {
+            $value: '10px',
+          },
+        });
+      }).toThrowError('Tokens validation error: instance.tokens.size-button.$value is not of a type(s) object');
+    });
+
+    test('accepts certain formats', () => {
+      expect(
+        validateTokens({
+          'size-button': {
+            $value: {
+              comfortable: '100px',
+              compact: '0rem',
+            },
+          },
+          'size-alert': {
+            $value: {
+              comfortable: '1.5em',
+              compact: '50%',
+            },
+          },
+        }),
+      ).toBe(true);
+    });
+
+    test('rejects invalid formats', () => {
+      ['100 px', '20ps', '100 %', '100px a', 'auto', 'none', 'inherit'].forEach((invalidValue) => {
+        expect(() =>
+          validateTokens({
+            'size-button': {
+              $value: {
+                comfortable: invalidValue,
+                compact: invalidValue,
+              },
+            },
+          }),
+        ).toThrowError(
+          'Tokens validation error: instance.tokens.size-button.$value.comfortable does not match pattern "^\\\\d+(\\\\.\\\\d+)?(px|rem|em|%)$"',
+        );
+      });
+    });
+  });
+
   describe('font-size', () => {
     test('accepts certain formats', () => {
       ['14px', '2rem', '1em', '1.5rem'].forEach((validValue) => {

--- a/src/build/tasks/theme-json-schema.ts
+++ b/src/build/tasks/theme-json-schema.ts
@@ -44,7 +44,7 @@ const letterSpacingValueSchema: GenericSchema = {
 };
 const sizeValueSchema: GenericSchema = {
   type: 'string',
-  pattern: '^\\d+(\\.\\d+)?(px|rem|em)$',
+  pattern: '^\\d+(\\.\\d+)?(px|rem|em|%)$',
 };
 const durationValueSchema: GenericSchema = { type: 'string', pattern: '\\d+m?s' };
 

--- a/src/build/tasks/theme-json-schema.ts
+++ b/src/build/tasks/theme-json-schema.ts
@@ -42,6 +42,10 @@ const letterSpacingValueSchema: GenericSchema = {
   type: 'string',
   pattern: '^(normal|inherit|initial|revert|revert-layer|unset|-?\\d*\\.?\\d+(px|rem|em))$',
 };
+const sizeValueSchema: GenericSchema = {
+  type: 'string',
+  pattern: '^\\d+(\\.\\d+)?(px|rem|em)$',
+};
 const durationValueSchema: GenericSchema = { type: 'string', pattern: '\\d+m?s' };
 
 const visualModes = ['light', 'dark'];
@@ -84,6 +88,7 @@ const tokensSchema: GenericSchema = {
     '^line-height-': getTokenSchema(textSizeValueSchema),
     '^font-weight-': getTokenSchema(textWeightValueSchema),
     '^letter-spacing-': getTokenSchema(letterSpacingValueSchema),
+    '^size-': getTokenSchema(getComplexValueSchema(sizeValueSchema, densityModes)),
   },
   additionalProperties: false,
 };

--- a/src/build/tasks/theme-json-schema.ts
+++ b/src/build/tasks/theme-json-schema.ts
@@ -44,7 +44,7 @@ const letterSpacingValueSchema: GenericSchema = {
 };
 const sizeValueSchema: GenericSchema = {
   type: 'string',
-  pattern: '^\\d+(\\.\\d+)?(px|rem|em|%)$',
+  pattern: '^(auto|\\d+(\\.\\d+)?(px|rem|em|%))$',
 };
 const durationValueSchema: GenericSchema = { type: 'string', pattern: '\\d+m?s' };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the `size` value schema for token validation. In the new Core theme project, we need to make a size token themeable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
