### PR TITLE
fix: preserve mode-dependent overrides in dark mode rules

### DIFF
--- a/src/browser/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/browser/__tests__/__snapshots__/index.test.ts.snap
@@ -13,6 +13,8 @@ exports[`applyTheme > with baseThemeId > attaches one style node containing over
 @media not print {.dark.dark.secondary-theme:not(#\\9){
 	--shadow-css:orange;
 	--boxShadow-css:var(--brown-css);
+	--buttonShadow-css:red;
+	--lineShadow-css:pink;
 }}
 .secondary-theme.secondary-theme .navigation:not(#\\9),.navigation.navigation.secondary-theme:not(#\\9){
 	--shadow-css:pink;
@@ -20,6 +22,8 @@ exports[`applyTheme > with baseThemeId > attaches one style node containing over
 @media not print {.dark.dark.secondary-theme .navigation:not(#\\9),.dark.dark.navigation.secondary-theme:not(#\\9){
 	--shadow-css:var(--grey-css);
 	--buttonShadow-css:green;
+	--boxShadow-css:var(--brown-css);
+	--lineShadow-css:pink;
 }}"
 `;
 
@@ -36,6 +40,8 @@ exports[`applyTheme > with secondary theme > attaches one style node containing 
 @media not print {.dark.dark:not(#\\9){
 	--shadow-css:orange;
 	--boxShadow-css:var(--brown-css);
+	--buttonShadow-css:red;
+	--lineShadow-css:pink;
 }}
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
@@ -44,6 +50,8 @@ exports[`applyTheme > with secondary theme > attaches one style node containing 
 @media not print {.dark.dark .navigation:not(#\\9),.dark.dark.navigation:not(#\\9){
 	--shadow-css:var(--brown-css);
 	--buttonShadow-css:green;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
 }}"
 `;
 
@@ -60,6 +68,8 @@ exports[`applyTheme > with targetDocument > attaches one style node containing o
 @media not print {.dark.dark:not(#\\9){
 	--shadow-css:orange;
 	--boxShadow-css:var(--brown-css);
+	--buttonShadow-css:red;
+	--lineShadow-css:pink;
 }}
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
@@ -68,6 +78,8 @@ exports[`applyTheme > with targetDocument > attaches one style node containing o
 @media not print {.dark.dark .navigation:not(#\\9),.dark.dark.navigation:not(#\\9){
 	--shadow-css:var(--brown-css);
 	--buttonShadow-css:green;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
 }}"
 `;
 
@@ -84,6 +96,8 @@ exports[`applyTheme > without secondary theme > attaches one style node containi
 @media not print {.dark.dark:not(#\\9){
 	--shadow-css:orange;
 	--boxShadow-css:var(--brown-css);
+	--buttonShadow-css:red;
+	--lineShadow-css:pink;
 }}
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
@@ -92,6 +106,8 @@ exports[`applyTheme > without secondary theme > attaches one style node containi
 @media not print {.dark.dark .navigation:not(#\\9),.dark.dark.navigation:not(#\\9){
 	--shadow-css:var(--brown-css);
 	--buttonShadow-css:green;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
 }}"
 `;
 
@@ -108,6 +124,8 @@ exports[`generateThemeStylesheet > with baseThemeId > creates override styles 1`
 @media not print {.dark.dark.secondary-theme:not(#\\9){
 	--shadow-css:orange;
 	--boxShadow-css:var(--brown-css);
+	--buttonShadow-css:red;
+	--lineShadow-css:pink;
 }}
 .secondary-theme.secondary-theme .navigation:not(#\\9),.navigation.navigation.secondary-theme:not(#\\9){
 	--shadow-css:pink;
@@ -115,6 +133,8 @@ exports[`generateThemeStylesheet > with baseThemeId > creates override styles 1`
 @media not print {.dark.dark.secondary-theme .navigation:not(#\\9),.dark.dark.navigation.secondary-theme:not(#\\9){
 	--shadow-css:var(--grey-css);
 	--buttonShadow-css:green;
+	--boxShadow-css:var(--brown-css);
+	--lineShadow-css:pink;
 }}"
 `;
 
@@ -138,6 +158,8 @@ exports[`generateThemeStylesheet > with secondary theme > creates override style
 @media not print {.dark.dark:not(#\\9){
 	--shadow-css:orange;
 	--boxShadow-css:var(--brown-css);
+	--buttonShadow-css:red;
+	--lineShadow-css:pink;
 }}
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
@@ -146,6 +168,8 @@ exports[`generateThemeStylesheet > with secondary theme > creates override style
 @media not print {.dark.dark .navigation:not(#\\9),.dark.dark.navigation:not(#\\9){
 	--shadow-css:var(--brown-css);
 	--buttonShadow-css:green;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
 }}"
 `;
 
@@ -162,6 +186,8 @@ exports[`generateThemeStylesheet > without secondary theme > creates override st
 @media not print {.dark.dark:not(#\\9){
 	--shadow-css:orange;
 	--boxShadow-css:var(--brown-css);
+	--buttonShadow-css:red;
+	--lineShadow-css:pink;
 }}
 .navigation.navigation:not(#\\9){
 	--shadow-css:pink;
@@ -170,5 +196,7 @@ exports[`generateThemeStylesheet > without secondary theme > creates override st
 @media not print {.dark.dark .navigation:not(#\\9),.dark.dark.navigation:not(#\\9){
 	--shadow-css:var(--brown-css);
 	--buttonShadow-css:green;
+	--boxShadow-css:purple;
+	--lineShadow-css:pink;
 }}"
 `;

--- a/src/shared/declaration/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/shared/declaration/__tests__/__snapshots__/index.test.ts.snap
@@ -1,5 +1,47 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`createOverrideDeclarations > does not add non-mode tokens to dark mode rule 1`] = `
+"body{
+	--fontFamilyBase-css:monospace;
+}"
+`;
+
+exports[`createOverrideDeclarations > preserves different-value mode tokens 1`] = `
+"body{
+	--black-css:black;
+	--grey-css:grey;
+	--brown-css:brown;
+	--shadow-css:yellow;
+}
+@media not print {.dark{
+	--shadow-css:orange;
+}}
+.navigation{
+	--shadow-css:var(--black-css);
+}
+@media not print {.dark .navigation,.dark.navigation{
+	--shadow-css:var(--brown-css);
+}}"
+`;
+
+exports[`createOverrideDeclarations > preserves same-value mode token in dark mode rule 1`] = `
+"body{
+	--black-css:black;
+	--grey-css:grey;
+	--brown-css:brown;
+	--shadow-css:red;
+}
+@media not print {.dark{
+	--shadow-css:red;
+}}
+.navigation{
+	--shadow-css:var(--black-css);
+}
+@media not print {.dark .navigation,.dark.navigation{
+	--shadow-css:var(--brown-css);
+}}"
+`;
+
 exports[`renderDeclarations > does not render unnecessary declarations 1`] = `
 "@layer cloudscape-base-theme {
 :global body{

--- a/src/shared/declaration/__tests__/index.test.ts
+++ b/src/shared/declaration/__tests__/index.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
 import { rootTheme, preset, secondaryTheme } from '../../../__fixtures__/common';
-import { createBuildDeclarations } from '..';
+import { createBuildDeclarations, createOverrideDeclarations } from '..';
+import { Override } from '../../theme';
 
 describe('renderDeclarations', () => {
   test('renders declarations for theme with :root selector and context', () => {
@@ -187,5 +188,39 @@ describe('renderDeclarations', () => {
     );
     expect(mergedRule).not.toBeNull();
     expect(mergedRule![1]).toContain('--shadow-css');
+  });
+});
+
+describe('createOverrideDeclarations', () => {
+  const selectorCustomizer = (selector: string) => selector;
+
+  test('preserves same-value mode token in dark mode rule', () => {
+    const override: Override = {
+      tokens: {
+        shadow: { light: 'red', dark: 'red' },
+      },
+    };
+    const output = createOverrideDeclarations(rootTheme, override, preset.propertiesMap, selectorCustomizer);
+    expect(output).toMatchSnapshot();
+  });
+
+  test('does not add non-mode tokens to dark mode rule', () => {
+    const override: Override = {
+      tokens: {
+        fontFamilyBase: 'monospace',
+      },
+    };
+    const output = createOverrideDeclarations(rootTheme, override, preset.propertiesMap, selectorCustomizer);
+    expect(output).toMatchSnapshot();
+  });
+
+  test('preserves different-value mode tokens', () => {
+    const override: Override = {
+      tokens: {
+        shadow: { light: 'yellow', dark: 'orange' },
+      },
+    };
+    const output = createOverrideDeclarations(rootTheme, override, preset.propertiesMap, selectorCustomizer);
+    expect(output).toMatchSnapshot();
   });
 });

--- a/src/shared/declaration/__tests__/transformer.test.ts
+++ b/src/shared/declaration/__tests__/transformer.test.ts
@@ -57,6 +57,29 @@ describe('MinimalTransformer', () => {
     expect(result.findRule('.child')).toBeUndefined();
   });
 
+  test('preserves overridden properties in mode rules even when values match root', () => {
+    const stylesheet = new Stylesheet();
+    const rootRule = new Rule('body:not(#\\9)');
+    rootRule.appendDeclaration(new Declaration('--color', '#ff0000'));
+    rootRule.appendDeclaration(new Declaration('--size', '10px'));
+    stylesheet.appendRuleWithPath(rootRule, []);
+
+    const modeRule = new Rule('.dark.dark:not(#\\9)', 'not print');
+    modeRule.appendDeclaration(new Declaration('--color', '#ff0000'));
+    modeRule.appendDeclaration(new Declaration('--size', '10px'));
+    stylesheet.appendRuleWithPath(modeRule, [rootRule]);
+
+    const transformer = new MinimalTransformer({
+      overriddenProperties: new Set(['--color']),
+    });
+    const result = transformer.transform(stylesheet);
+
+    const darkRule = result.findRule('.dark.dark:not(#\\9)');
+    expect(darkRule).toBeDefined();
+    expect(darkRule!.getAllDeclarations().some((d) => d.property === '--color')).toBe(true);
+    expect(darkRule!.getAllDeclarations().some((d) => d.property === '--size')).toBe(false);
+  });
+
   test('merges adjacent rules with identical declarations into a comma selector', () => {
     const stylesheet = new Stylesheet();
     const rootRule = new Rule(':root');

--- a/src/shared/declaration/index.ts
+++ b/src/shared/declaration/index.ts
@@ -86,7 +86,15 @@ export function createOverrideDeclarations(
     new UsedPropertyRegistry(propertiesMap, usedTokens),
   );
   const stylesheet = new SingleThemeCreator(minimalTheme, ruleCreator, base, propertiesMap).create();
-  return new MinimalTransformer().transform(stylesheet).toString();
+
+  const overriddenProperties = new Set<string>();
+  initialTokens.forEach((token) => {
+    if (token in propertiesMap && token in (base.tokenModeMap ?? {})) {
+      overriddenProperties.add(propertiesMap[token]);
+    }
+  });
+
+  return new MinimalTransformer({ overriddenProperties }).transform(stylesheet).toString();
 }
 
 export function createBuildDeclarations(

--- a/src/shared/declaration/transformer.ts
+++ b/src/shared/declaration/transformer.ts
@@ -11,6 +11,13 @@ export interface Transformer {
 }
 
 export class MinimalTransformer implements Transformer {
+  // Set of properties the consumer explicitly overrode when using new themes.
+  private overriddenProperties: Set<string>;
+
+  constructor(options?: { overriddenProperties?: Set<string> }) {
+    this.overriddenProperties = options?.overriddenProperties ?? new Set();
+  }
+
   transform(stylesheet: Stylesheet): Stylesheet {
     const rules = stylesheet.getAllRules();
     const rulesWithPath = rules.map((rule) => ({
@@ -50,6 +57,15 @@ export class MinimalTransformer implements Transformer {
 
       const firstSelector = getFirstSelector(rule.selector);
       const isModeRule = rule.isModeRule();
+
+      // Re-add overridden properties to prevent same values in dark/light mode to be accounted for (fixes AWSUI-61881).
+      if (isModeRule && this.overriddenProperties.size > 0) {
+        Object.keys(ruleValue).forEach((property) => {
+          if (this.overriddenProperties.has(property) && !(property in diff)) {
+            diff[property] = ruleValue[property];
+          }
+        });
+      }
 
       if (isGlobalSelector(firstSelector)) {
         rule.clear();


### PR DESCRIPTION
Fixes AWSUI-61881: The dark mode gets overridden when light and dark mode uses the same value in themes due to some optimizations.

*Issue #, if available:* AWSUI-61881

### How to test it locally:
- Create a simple react project that consumes cloudscape-design from npm
- Create a custom theme where a token has the same light as dark value (see appendix below)
- Checkout theming-core and build the theming-core project, copy the lib/browser/browser and lib/browser/shared folder and replace the corresponding ones in the `node_modules/@cloudscape-design/theming-runtime` package or use `npm link`.
- Run `npm run dev` and check how it looks like (and compare it with the current live theming-runtime from `@cloudscape-design/theming-runtime`)


### Appendix:
```typescript
applyMode(Mode.Dark);
applyTheme({
  theme: {
    tokens: {
      colorBorderButtonNormalDefault: {
        light: "pink",
        dark: "pink",
      },
    },
  },
});

export default function App() {
  return (
    <div style={{ padding: "20px" }}>
      <Button>Test</Button>
    </div>
  );
}

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
