### PR TITLE
refactor: CSS layer name and new tests

### DIFF
--- a/src/build/__tests__/__snapshots__/internal.test.ts.snap
+++ b/src/build/__tests__/__snapshots__/internal.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`builds internal themed components without errors 1`] = `
-"@layer cloudscape-base-theme {
+"@layer awsui-base-theme {
   :root {
     --font-family-base-91xi75:"Amazon Ember", "Helvetica Neue", Roboto, Arial, sans-serif;
     --color-orange-500-vz48fa:#ec7211;

--- a/src/build/__tests__/__snapshots__/public-secondary.test.ts.snap
+++ b/src/build/__tests__/__snapshots__/public-secondary.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Build-time theming of main theme with matching baseThemeId generates the correct css files 1`] = `
-"@layer cloudscape-base-theme {
+"@layer awsui-base-theme {
   body {
     --font-family-base-rpbu7d:"Amazon Ember", "Helvetica Neue", Roboto, Arial, sans-serif;
     --color-orange-500-25sm1g:#ec7211;
@@ -33,7 +33,7 @@ exports[`Build-time theming of main theme with matching baseThemeId generates th
 `;
 
 exports[`Build-time theming of secondary theme generates the correct css files 1`] = `
-"@layer cloudscape-base-theme {
+"@layer awsui-base-theme {
   body {
     --font-family-base-rpbu7d:"Amazon Ember", "Helvetica Neue", Roboto, Arial, sans-serif;
     --color-orange-500-25sm1g:#ec7211;

--- a/src/shared/declaration/__integ__/layer-override.test.ts
+++ b/src/shared/declaration/__integ__/layer-override.test.ts
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { test, expect } from 'vitest';
+import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
+import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
+import { getInlineStylesheets } from '../../../build/inline-stylesheets';
+import { generateThemeStylesheet } from '../../../browser';
+import { ThemePreset, resolveTheme, reduce, defaultsReducer } from '../../theme';
+import { calculatePropertiesMap } from '../../../build/properties';
+import { preset as inputPreset } from '../../../build/__tests__/__fixtures__/template/internal/generated/theming/index.js';
+
+/**
+ * These tests verify that CSS produced by generateThemeStylesheet / applyTheme
+ * (unlayered) takes priority over CSS produced via getInlineStylesheets
+ * (wrapped in @layer awsui-base-theme), which is the CSS generation path
+ * used by buildThemedComponentsInternal.
+ *
+ * Per the CSS Cascade Layers spec, unlayered styles always win over layered
+ * styles regardless of specificity or source order.
+ */
+
+// Recompute propertiesMap to match what buildThemedComponentsInternal would produce.
+const propertiesMap = calculatePropertiesMap([inputPreset.theme], inputPreset.variablesMap);
+const preset: ThemePreset = { ...inputPreset, propertiesMap };
+
+const resolution = reduce(resolveTheme(preset.theme), preset.theme, defaultsReducer());
+const allTokens = Object.keys(preset.theme.tokens);
+
+// getInlineStylesheets produces CSS with :global() wrappers (CSS modules syntax).
+// Strip them to get valid browser CSS.
+const buildCSS = getInlineStylesheets(
+  preset.theme,
+  [],
+  resolution,
+  preset.variablesMap,
+  propertiesMap,
+  allTokens,
+)[0].contents.replace(/:global\(([^)]+)\)/g, '$1');
+
+function setupTest(testFn: (page: LayerTestPage) => Promise<void>) {
+  return useBrowser(async (browser) => {
+    await browser.url('about:blank');
+    const page = new LayerTestPage(browser);
+    await page.waitForVisible('body');
+    await testFn(page);
+  });
+}
+
+test(
+  'generateThemeStylesheet override wins over build CSS',
+  setupTest(async (page) => {
+    const overrideCSS = generateThemeStylesheet({
+      override: { tokens: { colorBackgroundButtonPrimaryDefault: '#ff0000' } },
+      preset,
+    });
+    await page.injectStyles(overrideCSS);
+    await page.injectStyles(buildCSS);
+
+    expect(await page.getPropertyValue(propertiesMap.colorBackgroundButtonPrimaryDefault)).toBe('#ff0000');
+  }),
+);
+
+test(
+  'generateThemeStylesheet override wins for mode-specific tokens',
+  setupTest(async (page) => {
+    const overrideCSS = generateThemeStylesheet({
+      override: {
+        tokens: { colorBackgroundButtonPrimaryActive: { light: '#aaaaaa', dark: '#bbbbbb' } },
+      },
+      preset,
+    });
+    await page.injectStyles(overrideCSS);
+    await page.injectStyles(buildCSS);
+
+    expect(await page.getPropertyValue(propertiesMap.colorBackgroundButtonPrimaryActive)).toBe('#aaaaaa');
+
+    await page.addClassToRoot('dark-mode');
+    expect(await page.getPropertyValue(propertiesMap.colorBackgroundButtonPrimaryActive)).toBe('#bbbbbb');
+  }),
+);
+
+test(
+  'non-overridden tokens still resolve from build CSS',
+  setupTest(async (page) => {
+    const overrideCSS = generateThemeStylesheet({
+      override: { tokens: { colorBackgroundButtonPrimaryDefault: '#ff0000' } },
+      preset,
+    });
+    await page.injectStyles(overrideCSS);
+    await page.injectStyles(buildCSS);
+
+    expect(await page.getPropertyValue(propertiesMap.colorBackgroundButtonPrimaryDefault)).toBe('#ff0000');
+    expect(await page.getPropertyValue(propertiesMap.fontFamilyBase)).toBe(
+      "'Amazon Ember', 'Helvetica Neue', Roboto, Arial, sans-serif",
+    );
+  }),
+);
+
+class LayerTestPage extends BasePageObject {
+  async injectStyles(css: string): Promise<void> {
+    await this.browser.executeAsync((css: string, done: () => void) => {
+      const styleNode = document.createElement('style');
+      styleNode.appendChild(document.createTextNode(css));
+      document.querySelector('head')?.appendChild(styleNode);
+      done();
+    }, css);
+  }
+
+  async getPropertyValue(property: string): Promise<string> {
+    return this.browser.executeAsync((property: string, done: (result: string) => void) => {
+      done(getComputedStyle(document.documentElement).getPropertyValue(property).trim());
+    }, property);
+  }
+
+  async addClassToRoot(className: string): Promise<void> {
+    await this.browser.executeAsync((className: string, done: () => void) => {
+      document.documentElement.classList.add(className);
+      done();
+    }, className);
+  }
+}

--- a/src/shared/declaration/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/shared/declaration/__tests__/__snapshots__/index.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`renderDeclarations > does not render unnecessary declarations 1`] = `
-"@layer cloudscape-base-theme {
+"@layer awsui-base-theme {
 :global body{
 	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
 }
@@ -9,7 +9,7 @@ exports[`renderDeclarations > does not render unnecessary declarations 1`] = `
 `;
 
 exports[`renderDeclarations > includes secondary theme 1`] = `
-"@layer cloudscape-base-theme {
+"@layer awsui-base-theme {
 body{
 	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
 	--fontFamilyBody-css:var(--fontFamilyBase-css);
@@ -63,7 +63,7 @@ body{
 `;
 
 exports[`renderDeclarations > renders declarations for theme with :root selector and context 1`] = `
-"@layer cloudscape-base-theme {
+"@layer awsui-base-theme {
 :global body{
 	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
 	--fontFamilyBody-css:var(--fontFamilyBase-css);
@@ -106,7 +106,7 @@ exports[`renderDeclarations > renders declarations for theme with :root selector
 `;
 
 exports[`renderDeclarations > renders declarations for theme with non :root selector 1`] = `
-"@layer cloudscape-base-theme {
+"@layer awsui-base-theme {
 .secondary-theme{
 	--fontFamilyBase-css:"Helvetica Neue", Arial, sans-serif;
 	--fontFamilyBody-css:var(--fontFamilyBase-css);

--- a/src/shared/declaration/index.ts
+++ b/src/shared/declaration/index.ts
@@ -105,5 +105,5 @@ export function createBuildDeclarations(
     new UsedPropertyRegistry(propertiesMap, usedTokens),
   );
   const stylesheet = new MultiThemeCreator(themes, ruleCreator, propertiesMap).create();
-  return new MinimalTransformer().transform(stylesheet).toString('cloudscape-base-theme');
+  return new MinimalTransformer().transform(stylesheet).toString('awsui-base-theme');
 }


### PR DESCRIPTION
I changed the default layer name from "cloudscape-base-theme" to "awsui-base-theme" to be more generic - this matches the prefixes we use for design tokens and custom data attributes.

Additionally, I added new unit tests that ensure that runtime themes have priority over build time themes because the former do not include the CSS layer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
