### PR TITLE
feat: add font-decoration-* schema

### DIFF
--- a/src/build/tasks/__tests__/theme-json-schema.test.ts
+++ b/src/build/tasks/__tests__/theme-json-schema.test.ts
@@ -418,4 +418,56 @@ describe('validateJson', () => {
       });
     });
   });
+
+  describe('font-decoration-thickness', () => {
+    test('accepts certain formats', () => {
+      ['1px', '0.5em', '1rem', '10%', 'auto', 'from-font'].forEach((validValue) => {
+        expect(
+          validateTokens({
+            'font-decoration-thickness-link': {
+              $value: validValue,
+            },
+          }),
+        ).toBe(true);
+      });
+    });
+
+    test('rejects invalid formats', () => {
+      ['1', 'thin', '1 px'].forEach((invalidValue) => {
+        expect(() =>
+          validateTokens({
+            'font-decoration-thickness-link': {
+              $value: invalidValue,
+            },
+          }),
+        ).toThrowError('Tokens validation error');
+      });
+    });
+  });
+
+  describe('font-decoration-style', () => {
+    test('accepts valid values', () => {
+      ['solid', 'double', 'dotted', 'dashed', 'wavy', 'underline', 'none'].forEach((validValue) => {
+        expect(
+          validateTokens({
+            'font-decoration-style-link': {
+              $value: validValue,
+            },
+          }),
+        ).toBe(true);
+      });
+    });
+
+    test('rejects invalid values', () => {
+      ['bold', 'italic', '1px'].forEach((invalidValue) => {
+        expect(() =>
+          validateTokens({
+            'font-decoration-style-link': {
+              $value: invalidValue,
+            },
+          }),
+        ).toThrowError('Tokens validation error');
+      });
+    });
+  });
 });

--- a/src/build/tasks/theme-json-schema.ts
+++ b/src/build/tasks/theme-json-schema.ts
@@ -30,6 +30,14 @@ const borderWidthValueSchema: GenericSchema = {
   type: 'string',
   pattern: '^\\d+(\\.\\d+)?(px|rem|em)$',
 };
+const textDecorationThicknessValueSchema: GenericSchema = {
+  type: 'string',
+  pattern: '^(auto|from-font|0|(\\d+(\\.\\d+)?|\\.\\d+)(px|rem|em|%))$',
+};
+const textDecorationStyleValueSchema: GenericSchema = {
+  type: 'string',
+  pattern: '^(solid|double|dotted|dashed|wavy|none|underline|overline|line-through)$',
+};
 const textSizeValueSchema: GenericSchema = {
   type: 'string',
   pattern: '^\\d+(\\.\\d+)?(px|rem|em)$',
@@ -85,6 +93,8 @@ const tokensSchema: GenericSchema = {
     '^motion-keyframes-': getTokenSchema(getComplexValueSchema(stringValueSchema, motionModes)),
     '^shadow-': getTokenSchema(getComplexValueSchema(stringValueSchema, visualModes)),
     '^font-size-': getTokenSchema(textSizeValueSchema),
+    '^font-decoration-thickness-': getTokenSchema(textDecorationThicknessValueSchema),
+    '^font-decoration-style-': getTokenSchema(textDecorationStyleValueSchema),
     '^line-height-': getTokenSchema(textSizeValueSchema),
     '^font-weight-': getTokenSchema(textWeightValueSchema),
     '^letter-spacing-': getTokenSchema(letterSpacingValueSchema),


### PR DESCRIPTION
Add `font-decoration-thickness` and `font-decoration-style` schema patterns.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
