### PR TITLE
chore: Adds dependabot lockfile cleanup workflow

### DIFF
--- a/.github/workflows/dependabot-lockfile-cleanup.yml
+++ b/.github/workflows/dependabot-lockfile-cleanup.yml
@@ -1,0 +1,14 @@
+name: Dependabot lockfile cleanup
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    uses: cloudscape-design/actions/.github/workflows/dependabot-lockfile-cleanup.yml@main
+    secrets: inherit


### PR DESCRIPTION
This workflow adds extra commit to dependabot issued PRs to remove internal dependencies from package lock. We use it in several other repositories already.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
