### PR TITLE
chore: add current color css value to match

### DIFF
--- a/src/build/tasks/__tests__/theme-json-schema.test.ts
+++ b/src/build/tasks/__tests__/theme-json-schema.test.ts
@@ -111,6 +111,12 @@ describe('validateJson', () => {
               dark: 'transparent',
             },
           },
+          'color-text': {
+            $value: {
+              light: 'currentColor',
+              dark: 'currentColor',
+            },
+          },
         }),
       ).toBe(true);
 
@@ -125,7 +131,7 @@ describe('validateJson', () => {
             },
           }),
         ).toThrowError(
-          'Tokens validation error: instance.tokens.color-button.$value.light does not match pattern "#[0-9a-f]{6}|rgba\\\\(\\\\d{1,3}%?(,\\\\s?\\\\d{1,3}%?){2},\\\\s?(1|0|0?\\\\.\\\\d+)\\\\)|transparent"',
+          'Tokens validation error: instance.tokens.color-button.$value.light does not match pattern "#[0-9a-f]{6}|rgba\\\\(\\\\d{1,3}%?(,\\\\s?\\\\d{1,3}%?){2},\\\\s?(1|0|0?\\\\.\\\\d+)\\\\)|transparent|currentColor"',
         );
       });
     });

--- a/src/build/tasks/theme-json-schema.ts
+++ b/src/build/tasks/theme-json-schema.ts
@@ -20,7 +20,7 @@ interface GenericSchema {
 const stringValueSchema: GenericSchema = { type: 'string' };
 const colorValueSchema: GenericSchema = {
   type: 'string',
-  pattern: '#[0-9a-f]{6}|rgba\\(\\d{1,3}%?(,\\s?\\d{1,3}%?){2},\\s?(1|0|0?\\.\\d+)\\)|transparent',
+  pattern: '#[0-9a-f]{6}|rgba\\(\\d{1,3}%?(,\\s?\\d{1,3}%?){2},\\s?(1|0|0?\\.\\d+)\\)|transparent|currentColor',
 };
 const spaceValueSchema: GenericSchema = {
   type: 'string',


### PR DESCRIPTION
*Issue #, if available:* AWSUI-62072

*Description of changes:*
Allows `currentColor` as a valid CSS value in the theming pipeline so tokens can default to it. This unblocks exposing the link underline decoration tokens (`colorTextLinkDecorationDefault` / `colorTextLinkDecorationHover`), which default to `currentColor` to stay backward compatible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
