### PR TITLE
feat: Version-based token hashes

### DIFF
--- a/src/build/__tests__/names.test.ts
+++ b/src/build/__tests__/names.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
-import { toCssVarName, toSassName } from '../token';
+import { toCssVarName, toSassName, toStableCssVarName } from '../token';
 
 const reference = toCssVarName('color', ['red', 'blue']);
 
@@ -39,5 +39,25 @@ describe('toSassName', () => {
     ['font-font-family-base', '$font-font-family-base'],
   ])('%p becomes %p', (input, expected) => {
     expect(toSassName(input)).toBe(expected);
+  });
+});
+
+describe('toStableCssVarName', () => {
+  test('produces the --<name>-<hash> format', () => {
+    expect(toStableCssVarName('color-background', 'v3-1')).toMatch(/^--color-background-[0-9a-z]+$/);
+  });
+
+  test('is deterministic for the same inputs', () => {
+    expect(toStableCssVarName('color-background', 'v3-1')).toBe(toStableCssVarName('color-background', 'v3-1'));
+  });
+
+  test('differs between different tokens having the same version', () => {
+    expect(toStableCssVarName('color-a', 'v3-1')).not.toBe(toStableCssVarName('color-b', 'v3-1'));
+  });
+
+  test('changes when the version changes', () => {
+    const reference = toStableCssVarName('color-background', 'v3-1');
+    expect(toStableCssVarName('color-background', 'v3-2')).not.toBe(reference);
+    expect(toStableCssVarName('color-background', 'v4-1')).not.toBe(reference);
   });
 });

--- a/src/build/__tests__/properties.test.ts
+++ b/src/build/__tests__/properties.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { test, expect } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import { preset, rootTheme, secondaryTheme, navigationContext } from '../../__fixtures__/common';
 import { calculatePropertiesMap } from '../properties';
 
@@ -168,4 +168,82 @@ test('generates different hash if secondary theme defines the same token in a co
     preset.variablesMap,
   );
   expect(firstMap.shadow).not.toEqual(secondMap.shadow);
+});
+
+describe('stable version-based naming', () => {
+  test('stays stable when a token value changes', () => {
+    const first = calculatePropertiesMap(
+      [{ ...rootTheme, tokens: { shadow: { light: 'green', dark: 'blue' } }, contexts: {} }],
+      preset.variablesMap,
+      { shadow: 'v3-1' },
+    );
+    const second = calculatePropertiesMap(
+      [{ ...rootTheme, tokens: { shadow: { light: 'blue', dark: 'green' } }, contexts: {} }],
+      preset.variablesMap,
+      { shadow: 'v3-1' },
+    );
+    expect(first.shadow).toEqual(second.shadow);
+  });
+
+  test('stays stable when a context defines the same token', () => {
+    const first = calculatePropertiesMap(
+      [
+        {
+          ...rootTheme,
+          tokens: { shadow: { light: 'green', dark: 'blue' } },
+          contexts: { navigation: { ...navigationContext, tokens: {} } },
+        },
+      ],
+      preset.variablesMap,
+      { shadow: 'v3-1' },
+    );
+    const second = calculatePropertiesMap(
+      [
+        {
+          ...rootTheme,
+          tokens: { shadow: { light: 'green', dark: 'blue' } },
+          contexts: { navigation: { ...navigationContext, tokens: { shadow: 'black' } } },
+        },
+      ],
+      preset.variablesMap,
+      { shadow: 'v3-1' },
+    );
+    expect(first.shadow).toEqual(second.shadow);
+  });
+
+  test('stays stable when a secondary theme redefines the token', () => {
+    const first = calculatePropertiesMap(
+      [{ ...rootTheme, tokens: { shadow: { light: 'green', dark: 'blue' } }, contexts: {} }],
+      preset.variablesMap,
+      { shadow: 'v3-1' },
+    );
+    const second = calculatePropertiesMap(
+      [
+        { ...rootTheme, tokens: { shadow: { light: 'green', dark: 'blue' } }, contexts: {} },
+        { ...secondaryTheme, tokens: { shadow: 'black' }, contexts: {} },
+      ],
+      preset.variablesMap,
+      { shadow: 'v3-1' },
+    );
+    expect(first.shadow).toEqual(second.shadow);
+  });
+
+  test('migrates only allowlisted tokens, others stay legacy', () => {
+    const legacy = calculatePropertiesMap([rootTheme], preset.variablesMap);
+    const partial = calculatePropertiesMap([rootTheme], preset.variablesMap, { shadow: 'v3-1' });
+    expect(partial.shadow).not.toEqual(legacy.shadow);
+    expect(partial.boxShadow).toEqual(legacy.boxShadow);
+  });
+
+  test('an empty allowlist migrates nothing', () => {
+    const legacy = calculatePropertiesMap([rootTheme], preset.variablesMap);
+    const none = calculatePropertiesMap([rootTheme], preset.variablesMap, {});
+    expect(none).toEqual(legacy);
+  });
+
+  test('changes when the token version changes', () => {
+    const first = calculatePropertiesMap([rootTheme], preset.variablesMap, { shadow: 'v3-1' });
+    const second = calculatePropertiesMap([rootTheme], preset.variablesMap, { shadow: 'v3-2' });
+    expect(first.shadow).not.toEqual(second.shadow);
+  });
 });

--- a/src/build/internal.ts
+++ b/src/build/internal.ts
@@ -40,6 +40,8 @@ export interface BuildThemedComponentsInternalParams {
   jsonSchema?: boolean;
   /** Fail the build when SASS deprecation warning occurs **/
   failOnDeprecations?: boolean;
+  /** Allowlist of tokens to version strings for stable naming; unlisted tokens stay legacy. */
+  tokenVersions?: Record<string, string>;
 }
 /**
  * Builds themed components and optionally design tokens, if not skipped.
@@ -71,6 +73,7 @@ export async function buildThemedComponentsInternal(params: BuildThemedComponent
     descriptions = {},
     jsonSchema = false,
     failOnDeprecations,
+    tokenVersions,
   } = params;
 
   if (!skip.includes('design-tokens') && !designTokensOutputDir) {
@@ -82,7 +85,7 @@ export async function buildThemedComponentsInternal(params: BuildThemedComponent
   const resolution = resolveTheme(primary);
   const defaults = reduce(resolution, primary, defaultsReducer(null));
 
-  const propertiesMap = calculatePropertiesMap([primary, ...secondary], variablesMap);
+  const propertiesMap = calculatePropertiesMap([primary, ...secondary], variablesMap, tokenVersions);
   const styleTask = buildStyles(
     scssDir,
     componentsOutputDir,

--- a/src/build/properties.ts
+++ b/src/build/properties.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { FullResolution, Theme, ThemePreset, resolveContext, resolveTheme } from '../shared/theme';
-import { toCssVarName } from './token';
+import { toCssVarName, toStableCssVarName } from './token';
 
 interface TokensValuesMap {
   [token: string]: Array<string>;
@@ -10,6 +10,7 @@ interface TokensValuesMap {
 export function calculatePropertiesMap(
   themes: Array<Theme>,
   variablesMap: ThemePreset['variablesMap'],
+  tokenVersions?: Record<string, string>,
 ): Record<string, string> {
   const resolutions: Array<FullResolution> = [];
   themes.forEach((theme) => {
@@ -22,6 +23,10 @@ export function calculatePropertiesMap(
   const tokensValuesMap = getTokensValuesFromResolutions(resolutions);
 
   const mapEntries = Object.entries(tokensValuesMap).map(([token, values]) => {
+    const version = tokenVersions?.[token];
+    if (version !== undefined) {
+      return [token, toStableCssVarName(variablesMap[token], version)];
+    }
     return [token, toCssVarName(variablesMap[token], values.filter((value) => !!value) as Array<string>)];
   });
   return Object.fromEntries(mapEntries);

--- a/src/build/public.ts
+++ b/src/build/public.ts
@@ -57,6 +57,7 @@ export async function buildThemedComponents(params: BuildThemedComponentsParams)
     designTokensOutputDir,
     scssDir,
     designTokensFileName: preset.theme.id,
+    tokenVersions: preset.tokenVersions,
   });
 }
 
@@ -74,7 +75,11 @@ function createThemedPreset(preset: ThemePreset, override: Override, baseThemeId
     const themeIndex = (newPreset.secondary || []).findIndex((item) => item.id === theme.id);
     (newPreset.secondary || [])[themeIndex] = result;
   }
-  const propertiesMap = calculatePropertiesMap([newPreset.theme, ...(newPreset.secondary || [])], preset.variablesMap);
+  const propertiesMap = calculatePropertiesMap(
+    [newPreset.theme, ...(newPreset.secondary || [])],
+    preset.variablesMap,
+    preset.tokenVersions,
+  );
   newPreset.propertiesMap = propertiesMap;
 
   return newPreset;

--- a/src/build/token.ts
+++ b/src/build/token.ts
@@ -2,6 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import { getHashDigest } from 'loader-utils';
 
+/** Creates hashed token var name, where hash is computed from token identity and version. */
+export function toStableCssVarName(variable: string, version: string): string {
+  const hash = getHashDigest(Buffer.from(`${variable} ${version}`), 'md5', 'base36', 6);
+  return `--${variable}-${hash}`;
+}
+
+/** Used as fallback for toStableCssVarName when token versions are not given.  */
 export function toCssVarName(variable: string, values: string[]): string {
   const id = JSON.stringify([variable, ...values]);
   const hash = getHashDigest(Buffer.from(id), 'md5', 'base36', 6);

--- a/src/shared/theme/interfaces.ts
+++ b/src/shared/theme/interfaces.ts
@@ -127,4 +127,6 @@ export interface ThemePreset {
   propertiesMap: Record<Token, string>;
   /** Map between design tokens and variable names */
   variablesMap: Record<Token, string>;
+  /** Allowlist of tokens to version strings for stable naming; unlisted tokens stay legacy. */
+  tokenVersions?: Record<Token, string>;
 }


### PR DESCRIPTION
Introducing an alternative way of computing design token hashes. This takes an explicit version, declared per token instead of token's value - allowing the hash to persist even if the value changes, thus giving us granular control over such changes. The idea is to make token hashes stable across a wide range of component versions to make theming simpler.

This is a part of theming improvements project, see QUIP [XEEHAl8Q4kbb].

Once merged, it will be adopted in the components repository. Eventually, all tokens will be migrated over to use a single shared version, but in order to minimise risks - we will migrate tokens in batches. See the first one: https://github.com/cloudscape-design/components/pull/4718

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
