### PR TITLE
chore: Remediate 14 Dependabot security alerts (lockfile only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3686,9 +3686,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5686,9 +5686,9 @@
       "license": "MIT"
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "license": "MIT"
     },
     "node_modules/import-meta-resolve": {
@@ -5723,9 +5723,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6822,15 +6822,15 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -6872,9 +6872,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7320,9 +7320,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7339,7 +7339,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8557,9 +8557,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
## Automated Dependabot security-alert remediation

Alert-driven remediation of this repository's **open** Dependabot security alerts.
Baseline: `c2dae6a3c` on `main`.

> ### :warning: Read first — deliberate version choice for internal (Brazil/NPMPM) consumption
> This PR pins **postcss `8.5.25`** and **nanoid `3.3.16`** rather than npm's latest picks (`postcss@8.5.26` / `nanoid@3.3.17`).
> At the time of this run `postcss@8.5.26` had an **empty NpmPrettyMuch status** (3PAG scan still in progress; published the same day) and `nanoid@3.3.17` was **`⟳ in queue`** — neither is importable into NPMPM yet, and both are **non-dev** here, so they would have broken internal Brazil builds and shown **RED** on the NPMPM availability check.
> `postcss@8.5.25` still satisfies the advisory (first patched `8.5.18`) and both pinned versions are confirmed **`✓ exists`** in NpmPrettyMuch. No action needed from you — this note just explains why the versions are not the newest.

### Alerts resolved (14 of 14)

| Alert | Sev | Package | Major line | Vulnerable range | First patched | Now resolved to | Advisory |
|---|---|---|---|---|---|---|---|
| #154 | high | `brace-expansion` | 5.x | `>= 3.0.0, < 5.0.7` | 5.0.7 | `2.1.4, 5.0.9` | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) (CVE-2026-13149) |
| #162 | high | `brace-expansion` | 2.x | `>= 2.0.0, < 2.1.2` | 2.1.2 | `2.1.4, 5.0.9` | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) (CVE-2026-13149) |
| #165 | high | `brace-expansion` | 5.x | `>= 4.0.0, < 5.0.8` | 5.0.8 | `2.1.4, 5.0.9` | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (CVE-2026-14257) |
| #166 | high | `brace-expansion` | 2.x | `>= 2.0.0, < 2.1.3` | 2.1.3 | `2.1.4, 5.0.9` | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (CVE-2026-14257) |
| #169 | high | `brace-expansion` | 5.x | `>= 4.0.0, < 5.0.9` | 5.0.9 | `2.1.4, 5.0.9` | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (CVE-2026-69152) |
| #160 | high | `immutable` | 4.x | `< 4.3.9` | 4.3.9 | `4.3.9` | [GHSA-v56q-mh7h-f735](https://github.com/advisories/GHSA-v56q-mh7h-f735) (CVE-2026-59879) |
| #161 | high | `immutable` | 4.x | `< 4.3.9` | 4.3.9 | `4.3.9` | [GHSA-xvcm-6775-5m9r](https://github.com/advisories/GHSA-xvcm-6775-5m9r) (CVE-2026-59880) |
| #167 | medium | `ip-address` | 10.x | `>= 10.1.1, <= 10.2.0` | 10.2.1 | `10.4.0` | [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) (CVE-2026-54272) |
| #168 | medium | `ip-address` | 10.x | `>= 10.1.1, <= 10.2.1` | 10.2.2 | `10.4.0` | [GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh) (CVE-2026-69198) |
| #170 | high | `ip-address` | 10.x | `<= 10.3.0` | 10.3.1 | `10.4.0` | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr) (CVE-2026-69192) |
| #163 | high | `postcss` | 8.x | `<= 8.5.17` | 8.5.18 | `8.5.25` | [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) (—) |
| #171 | medium | `undici` | 6.x | `< 6.28.0` | 6.28.0 | `6.28.0` | [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) (CVE-2026-15157) |
| #172 | medium | `undici` | 6.x | `< 6.28.0` | 6.28.0 | `6.28.0` | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) (CVE-2026-16728) |
| #173 | medium | `undici` | 6.x | `< 6.28.0` | 6.28.0 | `6.28.0` | [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) (CVE-2026-16729) |

### How this was remediated

* **Rung 1 — `npm audit fix --package-lock-only --ignore-scripts`** (no `--force` was used anywhere in this run).
* The repo's own `prepare-package-lock` convention (`postinstall` in `@cloudscape-design/build-tools`) was applied afterwards, so no `@cloudscape-design/*` entries are (re-)introduced into the lockfile.
* npm's full reconciliation additionally healed unrelated pre-existing lockfile drift (stale entries, `dev`/`optional` flags, unrelated minor bumps). **That collateral was deliberately discarded**: only the security-relevant entries from npm's computed result were applied on top of the committed lockfile, so this diff contains alert-driven changes only.
* Verified with `npm ls --package-lock-only --all`: **zero new** unmet/invalid dependency problems versus `main`.

### Lockfile changes (7)

| Package | From | To | Scope | Lockfile path |
|---|---|---|---|---|
| `brace-expansion` | 2.0.3 | 2.1.4 | **non-dev** | `node_modules/brace-expansion` |
| `brace-expansion` | 5.0.6 | 5.0.9 | **non-dev** | `node_modules/minimatch/node_modules/brace-expansion` |
| `immutable` | 4.3.8 | 4.3.9 | **non-dev** | `node_modules/immutable` |
| `ip-address` | 10.2.0 | 10.4.0 | **non-dev** | `node_modules/ip-address` |
| `nanoid` | 3.3.12 | 3.3.16 | **non-dev** | `node_modules/nanoid` |
| `postcss` | 8.5.15 | 8.5.25 | **non-dev** | `node_modules/postcss` |
| `undici` | 6.27.0 | 6.28.0 | **non-dev** | `node_modules/undici` |

### NPMPM (NpmPrettyMuch) availability — internal build safety

Every **non-dev** lockfile dependency whose version increased was checked on `npmpm.corp.amazon.com` (the `NpmPrettyMuch` column specifically):

| Package | Version | NpmPrettyMuch status | Verdict |
|---|---|---|---|
| [`brace-expansion`](https://npmpm.corp.amazon.com/pkg/brace-expansion) | [2.1.4](https://npmpm.corp.amazon.com/pkg/brace-expansion/2.1.4) | `✓ exists` | **AVAILABLE** |
| [`brace-expansion`](https://npmpm.corp.amazon.com/pkg/brace-expansion) | [5.0.9](https://npmpm.corp.amazon.com/pkg/brace-expansion/5.0.9) | `✓ exists` | **AVAILABLE** |
| [`immutable`](https://npmpm.corp.amazon.com/pkg/immutable) | [4.3.9](https://npmpm.corp.amazon.com/pkg/immutable/4.3.9) | `✓ exists` | **AVAILABLE** |
| [`ip-address`](https://npmpm.corp.amazon.com/pkg/ip-address) | [10.4.0](https://npmpm.corp.amazon.com/pkg/ip-address/10.4.0) | `✓ exists` | **AVAILABLE** |
| [`nanoid`](https://npmpm.corp.amazon.com/pkg/nanoid) | [3.3.16](https://npmpm.corp.amazon.com/pkg/nanoid/3.3.16) | `✓ exists` | **AVAILABLE** |
| [`postcss`](https://npmpm.corp.amazon.com/pkg/postcss) | [8.5.25](https://npmpm.corp.amazon.com/pkg/postcss/8.5.25) | `✓ exists` | **AVAILABLE** |
| [`undici`](https://npmpm.corp.amazon.com/pkg/undici) | [6.28.0](https://npmpm.corp.amazon.com/pkg/undici/6.28.0) | `✓ exists` | **AVAILABLE** |

**Result: 7/7 AVAILABLE, 0 pending, 0 blocked/unknown.** No internal-build (Brazil) impact expected; the NPMPM availability check should come back green.

### Does merging clear this repository's alert list?

**Yes.** Merging this PR is expected to close **all 14** of this repository's currently-open Dependabot security alerts.

---

<sub>Existing Dependabot-authored PRs were deliberately **not** touched, reviewed, rebased, or closed by this run.</sub>

> Opened by roko-dependabot on behalf of @ernst-dev. Alert-driven remediation; not merged — a human must review and merge.
