### PR TITLE
feat: Add subpath stylesheet imports so class-name modules load under Node

### DIFF
--- a/src/build/__tests__/styles.test.ts
+++ b/src/build/__tests__/styles.test.ts
@@ -19,7 +19,8 @@ async function buildWithFixtures(
 
 test('simple styles build', async () => {
   const outDir = await buildWithFixtures('simple');
-  expect(readdirSync(outDir)).toEqual(['styles.css.js', 'styles.scoped.css', 'styles.selectors.js']);
+  // `internal` holds the empty stylesheet module, which the build emits in both stylesheet-import modes.
+  expect(readdirSync(outDir)).toEqual(['internal', 'styles.css.js', 'styles.scoped.css', 'styles.selectors.js']);
   const { default: styles } = await import(join(outDir, 'styles.css.js'));
   expect(styles).toMatchInlineSnapshot(`
     {
@@ -31,7 +32,7 @@ test('simple styles build', async () => {
 
 test('bundles all imports for styles.scss entry point', async () => {
   const outDir = await buildWithFixtures('dependencies');
-  expect(readdirSync(outDir)).toEqual(['styles.css.js', 'styles.scoped.css', 'styles.selectors.js']);
+  expect(readdirSync(outDir)).toEqual(['internal', 'styles.css.js', 'styles.scoped.css', 'styles.selectors.js']);
   const { default: styles } = await import(join(outDir, 'styles.css.js'));
   // includes class names from both files in the fixture
   expect(styles).toMatchInlineSnapshot(`
@@ -46,7 +47,7 @@ test('supports virtual stylesheets', async () => {
   const outDir = await buildWithFixtures('inlines', {
     inlines: [{ url: 'awsui:tokens', contents: '$color-background: #abcabc' }],
   });
-  expect(readdirSync(outDir)).toEqual(['styles.css.js', 'styles.scoped.css', 'styles.selectors.js']);
+  expect(readdirSync(outDir)).toEqual(['internal', 'styles.css.js', 'styles.scoped.css', 'styles.selectors.js']);
   const cssContent = readFileSync(join(outDir, 'styles.scoped.css'), 'utf8');
   expect(cssContent).toContain('#abcabc');
 });
@@ -68,7 +69,13 @@ test('throws an error if errors on deprecation warnings are enabled', async () =
 
 test('mirrors directory structure of the sources', async () => {
   const outDir = await buildWithFixtures('dir-structure');
-  expect(readdirSync(outDir)).toEqual(['styles.css.js', 'styles.scoped.css', 'styles.selectors.js', 'sub-component']);
+  expect(readdirSync(outDir)).toEqual([
+    'internal',
+    'styles.css.js',
+    'styles.scoped.css',
+    'styles.selectors.js',
+    'sub-component',
+  ]);
   expect(readdirSync(join(outDir, 'sub-component'))).toEqual([
     'styles.css.js',
     'styles.scoped.css',

--- a/src/build/__tests__/stylesheet-import.test.ts
+++ b/src/build/__tests__/stylesheet-import.test.ts
@@ -1,0 +1,153 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { buildStyles, getStylesheetPackageImports, StylesheetImport } from '../internal';
+
+const fixturesRoot = join(__dirname, '__fixtures__', 'scss-only');
+const outputRoot = join(__dirname, 'out', 'stylesheet-import');
+const emptyStylesheet = 'internal/generated/styles/empty-stylesheet.js';
+
+async function build(suiteName: string, stylesheetImport?: StylesheetImport, { manifest = true } = {}) {
+  const outDir = join(outputRoot, `${suiteName}-${stylesheetImport ?? 'default'}${manifest ? '' : '-bare'}`);
+  rmSync(outDir, { recursive: true, force: true });
+  await buildStyles(join(fixturesRoot, suiteName), outDir, [], { stylesheetImport });
+  if (manifest) {
+    // The imports map only resolves relative to a package scope, so the output needs a manifest for
+    // Node to resolve `#stylesheet/...` at all. Consuming packages already have one.
+    const pkg = { name: 'fixture', private: true, imports: getStylesheetPackageImports() };
+    writeFileSync(join(outDir, 'package.json'), JSON.stringify(pkg, null, 2));
+  }
+  return outDir;
+}
+
+function firstLine(path: string) {
+  return readFileSync(path, 'utf8').trim().split('\n')[0].trim();
+}
+
+/**
+ * Loads a class-name module the way a published package is loaded: in a separate Node process, with
+ * no bundler and no transform in the way. Vitest cannot stand in for this, because it resolves and
+ * transforms the module itself and so never exercises Node's own resolver.
+ */
+function loadWithNode(modulePath: string, nodeArgs: string[] = []) {
+  const entry = JSON.stringify(pathToFileURL(modulePath).href);
+  const result = spawnSync(
+    process.execPath,
+    [
+      ...nodeArgs,
+      '-e',
+      `import(${entry}).then(
+         module => console.log(JSON.stringify(module.default)),
+         error => { console.error(error.code ?? error.message); process.exit(1); },
+       )`,
+    ],
+    { encoding: 'utf8' },
+  );
+  // Node prepends a MODULE_TYPELESS_PACKAGE_JSON warning, so take the code from the last line.
+  const lines = result.stderr.trim().split('\n');
+  return { status: result.status, stdout: result.stdout.trim(), error: lines[lines.length - 1].trim() };
+}
+
+describe('emitted stylesheet import', () => {
+  test('defaults to a relative import, unchanged', async () => {
+    const outDir = await build('simple');
+    expect(firstLine(join(outDir, 'styles.css.js'))).toBe("import './styles.scoped.css';");
+  });
+
+  test('addresses the stylesheet from the output root in subpath mode', async () => {
+    const outDir = await build('dir-structure', 'subpath');
+    expect(firstLine(join(outDir, 'styles.css.js'))).toBe("import '#stylesheet/styles.scoped.css';");
+    expect(firstLine(join(outDir, 'sub-component', 'styles.css.js'))).toBe(
+      "import '#stylesheet/sub-component/styles.scoped.css';",
+    );
+  });
+
+  // Written in both modes so that a package can declare the `imports` map pointing at it, and only
+  // then switch the emitted specifiers over.
+  test.each(['relative', 'subpath'] as const)('writes the empty stylesheet in %s mode', async (mode) => {
+    const outDir = await build('simple', mode);
+    expect(existsSync(join(outDir, emptyStylesheet))).toBe(true);
+    // Holds no module syntax, so it loads whether the consuming package is read as ESM or CommonJS.
+    expect(readFileSync(join(outDir, emptyStylesheet), 'utf8')).not.toMatch(/^(?!\/\/).*\S/m);
+  });
+
+  test('does not change the class names it emits', async () => {
+    const [relative, subpath] = await Promise.all([build('dir-structure'), build('dir-structure', 'subpath')]);
+    for (const file of ['styles.selectors.js', join('sub-component', 'styles.selectors.js')]) {
+      expect(readFileSync(join(subpath, file), 'utf8')).toEqual(readFileSync(join(relative, file), 'utf8'));
+    }
+  });
+});
+
+describe('resolution by Node', () => {
+  let relativeDir: string;
+  let subpathDir: string;
+
+  beforeAll(async () => {
+    [relativeDir, subpathDir] = await Promise.all([build('simple'), build('simple', 'subpath')]);
+  });
+
+  test('cannot load a relative stylesheet import', () => {
+    const { status, error } = loadWithNode(join(relativeDir, 'styles.css.js'));
+    expect(status).toBe(1);
+    expect(error).toBe('ERR_UNKNOWN_FILE_EXTENSION');
+  });
+
+  test('loads the class names in subpath mode', () => {
+    const { status, stdout } = loadWithNode(join(subpathDir, 'styles.css.js'));
+    expect(status).toBe(0);
+    expect(JSON.parse(stdout)).toEqual(expect.objectContaining({ root: expect.any(String) }));
+  });
+
+  test('resolves to the real stylesheet under a bundler condition', () => {
+    // A bundler applies `module`, so it must still reach the stylesheet rather than the empty module.
+    // Node then fails on the `.css` extension, which is the only way to observe the branch was taken.
+    const { status, error } = loadWithNode(join(subpathDir, 'styles.css.js'), ['--conditions=module']);
+    expect(status).toBe(1);
+    expect(error).toBe('ERR_UNKNOWN_FILE_EXTENSION');
+  });
+
+  test('reports a missing imports map rather than resolving to something else', async () => {
+    const bare = await build('simple', 'subpath', { manifest: false });
+    const { status, error } = loadWithNode(join(bare, 'styles.css.js'));
+    expect(status).toBe(1);
+    expect(error).toBe('ERR_PACKAGE_IMPORT_NOT_DEFINED');
+  });
+});
+
+describe('getStylesheetPackageImports', () => {
+  test('sends Node to the empty module and everything else to the stylesheet', () => {
+    expect(getStylesheetPackageImports()).toEqual({
+      '#stylesheet/*': {
+        module: './*',
+        browser: './*',
+        node: `./${emptyStylesheet}`,
+        default: './*',
+      },
+    });
+  });
+
+  // Conditions match in declaration order, and a bundler targeting Node applies `module` and `node`
+  // together. With `node` first, those builds resolve to the empty module and ship no styles at all.
+  test('matches bundler conditions ahead of node', () => {
+    const conditions = Object.keys(getStylesheetPackageImports()['#stylesheet/*']);
+    expect(conditions.indexOf('module')).toBeLessThan(conditions.indexOf('node'));
+    expect(conditions.indexOf('browser')).toBeLessThan(conditions.indexOf('node'));
+    expect(conditions.indexOf('node')).toBeLessThan(conditions.indexOf('default'));
+  });
+
+  test('prefixes the targets when the build does not write into the package root', () => {
+    expect(getStylesheetPackageImports('lib/components')).toEqual({
+      '#stylesheet/*': {
+        module: './lib/components/*',
+        browser: './lib/components/*',
+        node: `./lib/components/${emptyStylesheet}`,
+        default: './lib/components/*',
+      },
+    });
+  });
+});

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -3,6 +3,7 @@
 export { buildThemedComponents, BuildThemedComponentsParams } from './public';
 export { toStableKeyframeName } from './token';
 export { generateThemeStylesheet, GenerateThemeStylesheetParams } from '../shared/theme-stylesheet';
+export { getStylesheetPackageImports, StylesheetImport } from './stylesheet-import';
 export {
   Theme,
   ThemePreset,

--- a/src/build/internal.ts
+++ b/src/build/internal.ts
@@ -9,8 +9,10 @@ import { createStandaloneContextFiles } from './tasks/standalone-contexts';
 import { getInlineStylesheets } from './inline-stylesheets';
 import { calculatePropertiesMap } from './properties';
 import findNeededTokens from './needed-tokens';
+import { getStylesheetPackageImports, StylesheetImport } from './stylesheet-import';
 
 export { buildStyles, InlineStylesheet, BuildStylesOptions };
+export { getStylesheetPackageImports, StylesheetImport };
 
 export type Tasks = 'preset' | 'design-tokens';
 
@@ -53,6 +55,11 @@ export interface BuildThemedComponentsInternalParams {
    * inline stylesheet as `$system`. Lets components gate build-variant specific output. Default: 'core'.
    */
   system?: string;
+  /**
+   * How the emitted class-name modules reference their stylesheet. Defaults to `'relative'`, which
+   * only a bundler can resolve. See {@link StylesheetImport}.
+   */
+  stylesheetImport?: StylesheetImport;
 }
 /**
  * Builds themed components and optionally design tokens, if not skipped.
@@ -87,6 +94,7 @@ export async function buildThemedComponentsInternal(params: BuildThemedComponent
     failOnDeprecations,
     tokenVersions,
     system = 'core',
+    stylesheetImport,
   } = params;
 
   if (!skip.includes('design-tokens') && !designTokensOutputDir) {
@@ -108,7 +116,7 @@ export async function buildThemedComponentsInternal(params: BuildThemedComponent
     scssDir,
     componentsOutputDir,
     getInlineStylesheets(basePrimary, baseSecondary, defaults, variablesMap, propertiesMap, neededTokens, system),
-    { failOnDeprecations },
+    { failOnDeprecations, stylesheetImport },
   );
   const internalTokensTask = createInternalTokenFiles(defaults, propertiesMap, componentsOutputDir);
 

--- a/src/build/public.ts
+++ b/src/build/public.ts
@@ -10,7 +10,7 @@ import { getContexts, getThemeFromPreset } from '../shared/theme/validate';
 
 export interface BuildThemedComponentsParams extends Pick<
   BuildThemedComponentsInternalParams,
-  'scssDir' | 'componentsOutputDir'
+  'scssDir' | 'componentsOutputDir' | 'stylesheetImport'
 > {
   /**
    * The `preset` contains the base/fallback theme upon which the custom theme will be applied.
@@ -38,6 +38,7 @@ export async function buildThemedComponents(params: BuildThemedComponentsParams)
     scssDir,
     override,
     baseThemeId,
+    stylesheetImport,
   } = params;
 
   const preset = createThemedPreset(originalPreset, override, baseThemeId);
@@ -58,6 +59,7 @@ export async function buildThemedComponents(params: BuildThemedComponentsParams)
     scssDir,
     designTokensFileName: preset.theme.id,
     tokenVersions: preset.tokenVersions,
+    stylesheetImport,
   });
 }
 

--- a/src/build/stylesheet-import.ts
+++ b/src/build/stylesheet-import.ts
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import path from 'path';
+
+/**
+ * How an emitted class-name module (`*.css.js`) references the stylesheet it belongs to.
+ *
+ * `'relative'` emits `import './styles.scoped.css'`. Bundlers resolve that, but Node has no loader
+ * for `.css` and fails with `ERR_UNKNOWN_FILE_EXTENSION`, which makes every module that reaches a
+ * class-name map unloadable — including the package's own entry point. That blocks native `node`, and
+ * with it Vite SSR in its default configuration, where dependencies are externalized and handed to
+ * Node rather than bundled.
+ *
+ * `'subpath'` emits `import '#stylesheet/<path>'`. Node resolves subpath imports through the
+ * consuming package's own `imports` map, and unlike `exports` that map also applies to
+ * package-internal imports, which is what a relative stylesheet import is. The map points bundlers at
+ * the real stylesheet and Node at an empty module, so the class-name map loads under Node while the
+ * stylesheet is still bundled everywhere else.
+ *
+ * The consuming package has to merge {@link getStylesheetPackageImports} into its manifest for
+ * `'subpath'` to resolve at all; without it Node fails with `ERR_PACKAGE_IMPORT_NOT_DEFINED`. That is
+ * why this is opt-in.
+ */
+export type StylesheetImport = 'relative' | 'subpath';
+
+const stylesheetSubpathPrefix = '#stylesheet';
+
+/**
+ * What Node resolves a stylesheet import to. Written by the build in both modes, so that a package
+ * can declare the `imports` map naming it, and switch the emitted specifiers over separately.
+ *
+ * It holds no `export` statement on purpose: a comment-only file is valid as both CommonJS and ESM,
+ * so it stays loadable however the consuming package is interpreted.
+ */
+const emptyStylesheet = {
+  path: 'internal/generated/styles/empty-stylesheet.js',
+  contents: [
+    '// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.',
+    '// SPDX-License-Identifier: Apache-2.0',
+    '// Stands in for a stylesheet where one cannot be loaded, so that the class-name module importing',
+    "// it stays importable. Mapped in this package's `imports` field; see the theming-build docs for",
+    '// `getStylesheetPackageImports`.',
+    '',
+  ].join('\n'),
+};
+
+export function getEmptyStylesheet(): { path: string; contents: string } {
+  return { ...emptyStylesheet };
+}
+
+export function getStylesheetSpecifier(relativeStylesheetPath: string, stylesheetImport: StylesheetImport): string {
+  const posixPath = relativeStylesheetPath.split(path.sep).join('/');
+  if (stylesheetImport === 'relative') {
+    return `./${path.posix.basename(posixPath)}`;
+  }
+  return `${stylesheetSubpathPrefix}/${posixPath}`;
+}
+
+/**
+ * The `imports` entry that resolves the stylesheet imports emitted in `'subpath'` mode. Merge the
+ * result into the `package.json` of the package that ships the build output.
+ *
+ * The conditions, and their order, are measured rather than assumed:
+ *
+ * - Every bundler applies `module`, including when it targets Node to build an SSR bundle (measured
+ *   for webpack 5, Vite, esbuild and Rollup). Listing `module` and `browser` first is what keeps the
+ *   real stylesheet in bundled output.
+ * - Node applies only `node`, `import`/`require` and `module-sync`, so `node` selects the empty
+ *   module and the class-name map becomes loadable.
+ * - `node` must come after `module` and `browser`, not first. Keyed first it also matches webpack
+ *   with `target: 'node'`, `vite build --ssr` under `ssr.noExternal`, `esbuild --platform=node` and
+ *   Rollup with `exportConditions: ['node']`, each of which then produces a green build carrying the
+ *   class names but no stylesheet at all.
+ * - `default` maps to the stylesheet, not the empty module, so that a resolver applying none of the
+ *   above fails loudly on the `.css` extension instead of quietly dropping every style.
+ *
+ * Two consequences to be aware of:
+ *
+ * - Vitest applies `node` but neither `module` nor `browser`, having removed `module` from Vite's
+ *   server conditions, so it resolves to the empty module. This only shows up under `css: true`,
+ *   since Vitest replaces stylesheets with stubs by default; a consumer that needs them can add
+ *   `resolve.conditions: ['module']`.
+ * - webpack 4 does not implement the `imports` field, so it cannot resolve these specifiers at all.
+ *   It fails loudly, and `resolve.alias: { '#stylesheet': '<package root>' }` restores it.
+ *
+ * @param outputDirFromPackageRoot the directory the build writes into, relative to the root of the
+ *   package that will carry this manifest. Defaults to `'.'`, which is correct when the build writes
+ *   straight into the package root.
+ */
+export function getStylesheetPackageImports(outputDirFromPackageRoot = '.'): Record<string, Record<string, string>> {
+  const prefix = path.posix.normalize(`${outputDirFromPackageRoot.split(path.sep).join('/')}/`).replace(/^\.\//, '');
+  const stylesheet = `./${prefix}*`;
+  return {
+    [`${stylesheetSubpathPrefix}/*`]: {
+      module: stylesheet,
+      browser: stylesheet,
+      node: `./${prefix}${emptyStylesheet.path}`,
+      default: stylesheet,
+    },
+  };
+}

--- a/src/build/tasks/postcss/index.ts
+++ b/src/build/tasks/postcss/index.ts
@@ -10,6 +10,7 @@ import postCSSModules from 'postcss-modules';
 import postCSSIncreaseSpecificity from './increase-specifity';
 import { createRelativeScopedNameFunction } from './generate-scoped-name';
 import { writeCssModule } from './write-css-modules';
+import { StylesheetImport } from '../../stylesheet-import';
 
 export const scopedFileExt = '.scoped.css';
 
@@ -31,14 +32,20 @@ export const postCSSAfterAll = (input: string, filename: string) => {
   ]).process(input, { from: filename });
 };
 
-export const postCSSForEach = (sourceDir: string, outputDir: string, input: string, filename: string) => {
+export const postCSSForEach = (
+  sourceDir: string,
+  outputDir: string,
+  input: string,
+  filename: string,
+  stylesheetImport: StylesheetImport = 'relative',
+) => {
   return postcss([
     // inline local svg before creating module
     postCSSInlineSVG(),
     postCSSModules({
       generateScopedName: createRelativeScopedNameFunction(sourceDir),
       getJSON(cssFileName: string, json: Record<string, string>) {
-        writeCssModule(path.relative(sourceDir, cssFileName), outputDir, scopedFileExt, json);
+        writeCssModule(path.relative(sourceDir, cssFileName), outputDir, scopedFileExt, json, stylesheetImport);
       },
     }),
   ]).process(input, { from: filename });

--- a/src/build/tasks/postcss/write-css-modules.ts
+++ b/src/build/tasks/postcss/write-css-modules.ts
@@ -3,6 +3,8 @@
 import fs from 'fs';
 import path, { dirname } from 'path';
 
+import { getStylesheetSpecifier, StylesheetImport } from '../../stylesheet-import';
+
 function writeFile(path: string, content: any) {
   const dir = dirname(path);
   fs.mkdirSync(dir, { recursive: true });
@@ -14,13 +16,15 @@ export function writeCssModule(
   targetFolder: string,
   scopedFileExt: string,
   json: Record<string, unknown>,
+  stylesheetImport: StylesheetImport = 'relative',
 ): void {
   const modulePath = path.join(targetFolder, relativeCssPath);
   const stylesFilename = path.basename(relativeCssPath, '.css');
+  const stylesheetPath = path.join(path.dirname(relativeCssPath), stylesFilename + scopedFileExt);
 
   // language=JavaScript
   const content = `
-    import './${stylesFilename}${scopedFileExt}';
+    import '${getStylesheetSpecifier(stylesheetPath, stylesheetImport)}';
     export default ${JSON.stringify(json, null, 2)};
   `;
   writeFile(modulePath + '.js', content);

--- a/src/build/tasks/style.ts
+++ b/src/build/tasks/style.ts
@@ -6,6 +6,8 @@ import { postCSSForEach, postCSSAfterAll, scopedFileExt } from './postcss';
 import path from 'path';
 import fs from 'fs';
 import { pathToFileURL } from 'url';
+import { writeFile } from '../file';
+import { getEmptyStylesheet, StylesheetImport } from '../stylesheet-import';
 
 export interface InlineStylesheet {
   url: string;
@@ -14,6 +16,11 @@ export interface InlineStylesheet {
 
 export interface BuildStylesOptions {
   failOnDeprecations?: boolean;
+  /**
+   * How the emitted class-name modules reference their stylesheet. Defaults to `'relative'`, which
+   * only a bundler can resolve. See {@link StylesheetImport}.
+   */
+  stylesheetImport?: StylesheetImport;
 }
 
 export async function buildStyles(
@@ -26,6 +33,10 @@ export async function buildStyles(
   const compiler = createCompiler(inlines, outputDir, sassDir, options);
 
   const promises = files.map((file) => compiler(file));
+  // Written in both modes, so a package can declare the `imports` map that points at it before it
+  // switches the emitted specifiers over. See `getStylesheetPackageImports`.
+  const { path: emptyStylesheetPath, contents } = getEmptyStylesheet();
+  promises.push(writeFile(path.join(outputDir, emptyStylesheetPath), contents));
 
   await Promise.all(promises);
 }
@@ -90,7 +101,13 @@ function createCompiler(inlines: InlineStylesheet[], outputDir: string, sassDir:
       throw new Error('Unexpected deprecation warnings during sass build.');
     }
     const intermediate = path.join(sassDir, rename(file, '.css'));
-    const postCSSForEachResult = await postCSSForEach(sassDir, outputDir, sassResult.css, intermediate);
+    const postCSSForEachResult = await postCSSForEach(
+      sassDir,
+      outputDir,
+      sassResult.css,
+      intermediate,
+      options.stylesheetImport,
+    );
     const postCSSAfterAllResult = await postCSSAfterAll(postCSSForEachResult.css, intermediate);
 
     const output = path.join(outputDir, rename(file, scopedFileExt));


### PR DESCRIPTION
Part of adding support for Node's ESM resolver: cloudscape-design/components#4948

## The problem

Each emitted `*.css.js` starts with `import './styles.scoped.css'`, and Node has no loader for `.css`.

## The solution

This PR adds a `stylesheetImport: 'subpath'` option that makes the build emit `import '#stylesheet/<path>'` in place of a relative `.css` path. Node resolves a `#`-prefixed specifier through the `imports` field of the package that contains the importing file. Here's what that field would look like in `cloudscape-design/components`:

```json
"imports": {
  "#stylesheet/*": {
    "module": "./lib/components/*",
    "browser": "./lib/components/*",
    "node": "./lib/components/internal/generated/styles/empty-stylesheet.js",
    "default": "./lib/components/*"
  }
}
```

That mapping would give Node an empty placeholder for stylesheets (`empty-stylesheet.js`), since it has no way to parse CSS. Bundlers would still get the actual stylesheets.

I've verified that this works under Vite 8's SSR mode with `ssr.noExternal`: The server build gets the placeholders (since stylesheets aren't needed for SSR), the client build bundles and serves them.

Two consequences worth knowing about:

- Vitest resolves `node` imports by default, so this would make it resolve styles to an empty module. If using Vitest with `css: true` to add CSS support in a simulated DOM, set `resolve.conditions: ['module']`. (Cloudscape currently uses Jest, which doesn't have CSS support. Just noting in case Cloudscape migrates to Vitest in the future.)
- webpack 4 does not implement the `imports` field and cannot resolve these specifiers at all. It fails loudly, and `resolve.alias: { '#stylesheet': '<package root>' }` restores it.
