### PR TITLE
chore: Introduces stable keyframes helper

### DIFF
--- a/src/build/__tests__/token.test.ts
+++ b/src/build/__tests__/token.test.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, test } from 'vitest';
+import { toStableKeyframeName } from '../token';
+
+describe('toStableKeyframeName', () => {
+  test('derives a stable name from base name and version only', () => {
+    // Fixed value: any drift here would change animation names across the ecosystem.
+    expect(toStableKeyframeName('awsui-fade-in', 'v3-1')).toBe('awsui-fade-in-jiml2r');
+  });
+
+  test('changes with the version', () => {
+    expect(toStableKeyframeName('awsui-fade-in', 'v3-1')).not.toBe(toStableKeyframeName('awsui-fade-in', 'v3-2'));
+  });
+
+  test('changes with the base name', () => {
+    expect(toStableKeyframeName('awsui-fade-in', 'v3-1')).not.toBe(toStableKeyframeName('awsui-fade-out', 'v3-1'));
+  });
+});

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 export { buildThemedComponents, BuildThemedComponentsParams } from './public';
+export { toStableKeyframeName } from './token';
 export {
   Theme,
   ThemePreset,

--- a/src/build/token.ts
+++ b/src/build/token.ts
@@ -4,17 +4,28 @@ import { getHashDigest } from 'loader-utils';
 
 /** Creates hashed token var name, where hash is computed from token identity and version. */
 export function toStableCssVarName(variable: string, version: string): string {
-  const hash = getHashDigest(Buffer.from(`${variable} ${version}`), 'md5', 'base36', 6);
-  return `--${variable}-${hash}`;
+  return `--${variable}-${stableHash(`${variable} ${version}`)}`;
 }
 
 /** Used as fallback for toStableCssVarName when token versions are not given.  */
 export function toCssVarName(variable: string, values: string[]): string {
   const id = JSON.stringify([variable, ...values]);
-  const hash = getHashDigest(Buffer.from(id), 'md5', 'base36', 6);
-  return `--${variable}-${hash}`;
+  return `--${variable}-${stableHash(id)}`;
+}
+
+/**
+ * Creates a stable keyframes/animation name from a base name and version, using the same
+ * name+version hashing as `toStableCssVarName`.
+ */
+export function toStableKeyframeName(name: string, version: string): string {
+  return `${name}-${stableHash(`${name} ${version}`)}`;
 }
 
 export function toSassName(variable: string): string {
   return `$${variable}`;
+}
+
+/** Stable 6-char hash (md5 -> base36) from a string identity. */
+function stableHash(id: string): string {
+  return getHashDigest(Buffer.from(id), 'md5', 'base36', 6) as string;
 }


### PR DESCRIPTION
Same as https://github.com/cloudscape-design/theming-core/pull/190, but for keyframes, which also use hashes that depend on the shared styles file content.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
