### PR TITLE
chore: Adds awsui environment

### DIFF
--- a/src/build/__tests__/inline-stylesheets.test.ts
+++ b/src/build/__tests__/inline-stylesheets.test.ts
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { test, expect } from 'vitest';
+import { getInlineStylesheets } from '../inline-stylesheets';
+import { resolveTheme, reduce, defaultsReducer } from '../../shared/theme';
+import { calculatePropertiesMap } from '../properties';
+import { preset } from './__fixtures__/template/internal/generated/theming/index.js';
+
+const propertiesMap = calculatePropertiesMap([preset.theme], preset.variablesMap);
+const resolution = reduce(resolveTheme(preset.theme), preset.theme, defaultsReducer());
+const allTokens = Object.keys(preset.theme.tokens);
+
+function build(system?: string) {
+  return getInlineStylesheets(preset.theme, [], resolution, preset.variablesMap, propertiesMap, allTokens, system);
+}
+
+test('exposes the provided build system via an awsui:environment stylesheet', () => {
+  const environment = build('console').find((sheet) => sheet.url === 'awsui:environment');
+  expect(environment).toBeDefined();
+  expect(environment!.contents).toBe("$system: 'console';");
+});
+
+test('defaults $system to core when no system is provided', () => {
+  const environment = build().find((sheet) => sheet.url === 'awsui:environment');
+  expect(environment!.contents).toBe("$system: 'core';");
+});
+
+test('keeps awsui:globals first so index-based callers are unaffected', () => {
+  expect(build()[0].url).toBe('awsui:globals');
+});

--- a/src/build/inline-stylesheets.ts
+++ b/src/build/inline-stylesheets.ts
@@ -19,6 +19,7 @@ export function getInlineStylesheets(
   variablesMap: Record<string, string>,
   propertiesMap: Record<string, string>,
   neededTokens: string[],
+  system = 'core',
 ): InlineStylesheet[] {
   const declarations = createBuildDeclarations(
     primary,
@@ -46,5 +47,10 @@ export function getInlineStylesheets(
       .join(',\n')}];`,
   };
 
-  return [declaration, mapping, resolvedTokens];
+  const environment = {
+    url: 'awsui:environment',
+    contents: `$system: '${system}';`,
+  };
+
+  return [declaration, mapping, resolvedTokens, environment];
 }

--- a/src/build/internal.ts
+++ b/src/build/internal.ts
@@ -48,18 +48,24 @@ export interface BuildThemedComponentsInternalParams {
   failOnDeprecations?: boolean;
   /** Allowlist of tokens to version strings for stable naming; unlisted tokens stay legacy. */
   tokenVersions?: Record<string, string>;
+  /**
+   * Build system identifier (e.g. 'core', 'console'), exposed to SCSS via the `awsui:environment`
+   * inline stylesheet as `$system`. Lets components gate build-variant specific output. Default: 'core'.
+   */
+  system?: string;
 }
 /**
  * Builds themed components and optionally design tokens, if not skipped.
  *
- * The styles will be build with three inline stylesheets:
- * * `awsui:environment` - Stylesheet containing a simple environment context
+ * The styles will be built with four inline stylesheets:
  * * `awsui:globals` - Root stylesheet with custom property assignments
- * * `awsui:tokens`  - Mapping between SASS variables and var() assignments
+ * * `awsui:tokens` - Mapping between SASS variables and var() assignments
+ * * `awsui:resolved-tokens` - Resolved token values per theme selector
+ * * `awsui:environment` - Build environment context, exposing `$system` (e.g. 'core' / 'console')
  *
- * If designTokensOuputDir is specified and not skipped, three with designTokensFileName will be generated:
- * * Typescript
- * * Typescript definitions
+ * If designTokensOutputDir is specified and not skipped, three files with designTokensFileName will be generated:
+ * * TypeScript
+ * * TypeScript definitions
  * * SCSS
  *
  * @param params build themed components parameters
@@ -80,6 +86,7 @@ export async function buildThemedComponentsInternal(params: BuildThemedComponent
     jsonSchema = false,
     failOnDeprecations,
     tokenVersions,
+    system = 'core',
   } = params;
 
   if (!skip.includes('design-tokens') && !designTokensOutputDir) {
@@ -100,7 +107,7 @@ export async function buildThemedComponentsInternal(params: BuildThemedComponent
   const styleTask = buildStyles(
     scssDir,
     componentsOutputDir,
-    getInlineStylesheets(basePrimary, baseSecondary, defaults, variablesMap, propertiesMap, neededTokens),
+    getInlineStylesheets(basePrimary, baseSecondary, defaults, variablesMap, propertiesMap, neededTokens, system),
     { failOnDeprecations },
   );
   const internalTokensTask = createInternalTokenFiles(defaults, propertiesMap, componentsOutputDir);


### PR DESCRIPTION
The `awsui:environment` is a placeholder in SASS to be populated at build time with "core" or "console" targets. This will be used to add Style API CSS conditionally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
