### PR TITLE
fix: Name the emitted file in theming-runtime's relative imports

### DIFF
--- a/src/browser/__tests__/dom.test.ts
+++ b/src/browser/__tests__/dom.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect, afterEach } from 'vitest';
-import { getNonce, createStyleNode, appendStyleNode } from '../dom';
+import { getNonce, createStyleNode, appendStyleNode } from '../dom.js';
 
 function addMetaTag(name: string, content: string, targetDocument: Document = document) {
   const node = document.createElement('meta');

--- a/src/browser/__tests__/index.test.ts
+++ b/src/browser/__tests__/index.test.ts
@@ -11,10 +11,10 @@ import {
   presetWithSeedColor,
   presetWithExplicitPalette,
   overrideWithSeedColor,
-} from '../../__fixtures__/common';
-import { applyTheme, generateThemeStylesheet } from '../index';
-import { Theme, ThemePreset, Override } from '../../shared/theme';
-import { processReferenceTokens } from '../../shared/theme/process';
+} from '../../__fixtures__/common.js';
+import { applyTheme, generateThemeStylesheet } from '../index.js';
+import { Theme, ThemePreset, Override } from '../../shared/theme/index.js';
+import { processReferenceTokens } from '../../shared/theme/process.js';
 
 const allStyleNodes = (targetDocument: Document = document) => targetDocument.head.querySelectorAll('style');
 

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Override, ThemePreset } from '../shared/theme';
-import { generateThemeStylesheet } from '../shared/theme-stylesheet';
-import { getNonce, createStyleNode, appendStyleNode } from './dom';
+import { Override, ThemePreset } from '../shared/theme/index.js';
+import { generateThemeStylesheet } from '../shared/theme-stylesheet.js';
+import { getNonce, createStyleNode, appendStyleNode } from './dom.js';
 
-export { generateThemeStylesheet, GenerateThemeStylesheetParams } from '../shared/theme-stylesheet';
+export { generateThemeStylesheet, GenerateThemeStylesheetParams } from '../shared/theme-stylesheet.js';
 
 export interface ApplyThemeParams {
   override: Override;
@@ -45,4 +45,4 @@ export {
   ColorReferenceTokens,
   ReferencePaletteDefinition,
   processColorPaletteInput,
-} from '../shared/theme';
+} from '../shared/theme/index.js';

--- a/src/shared/__tests__/utils.test.ts
+++ b/src/shared/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, test } from 'vitest';
-import { jsonToSass } from '../utils';
+import { jsonToSass } from '../utils.js';
 
 describe('jsonToSass', () => {
   test('converts json to sass map', () => {

--- a/src/shared/declaration/__integ__/browser.test.ts
+++ b/src/shared/declaration/__integ__/browser.test.ts
@@ -3,10 +3,10 @@
 import { test, expect } from 'vitest';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
-import { rootTheme, preset, colorMode, navigationContext, defaultsResolution } from '../../../__fixtures__/common';
-import { createMultiThemeCustomizer, singleThemeCustomizer } from '../../declaration/customizer';
-import { createBuildDeclarations, createOverrideDeclarations } from '..';
-import { OptionalState, Override } from '../../theme';
+import { rootTheme, preset, colorMode, navigationContext, defaultsResolution } from '../../../__fixtures__/common.js';
+import { createMultiThemeCustomizer, singleThemeCustomizer } from '../../declaration/customizer.js';
+import { createBuildDeclarations, createOverrideDeclarations } from '../index.js';
+import { OptionalState, Override } from '../../theme/index.js';
 
 test(
   'resolves properties for root',

--- a/src/shared/declaration/__integ__/layer-override.test.ts
+++ b/src/shared/declaration/__integ__/layer-override.test.ts
@@ -3,10 +3,10 @@
 import { test, expect } from 'vitest';
 import useBrowser from '@cloudscape-design/browser-test-tools/use-browser';
 import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objects';
-import { getInlineStylesheets } from '../../../build/inline-stylesheets';
-import { generateThemeStylesheet } from '../../../browser';
-import { ThemePreset, resolveTheme, reduce, defaultsReducer } from '../../theme';
-import { calculatePropertiesMap } from '../../../build/properties';
+import { getInlineStylesheets } from '../../../build/inline-stylesheets.js';
+import { generateThemeStylesheet } from '../../../browser/index.js';
+import { ThemePreset, resolveTheme, reduce, defaultsReducer } from '../../theme/index.js';
+import { calculatePropertiesMap } from '../../../build/properties.js';
 import { preset as inputPreset } from '../../../build/__tests__/__fixtures__/template/internal/generated/theming/index.js';
 
 /**

--- a/src/shared/declaration/__tests__/index.test.ts
+++ b/src/shared/declaration/__tests__/index.test.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
-import { rootTheme, preset, secondaryTheme } from '../../../__fixtures__/common';
-import { createBuildDeclarations } from '..';
+import { rootTheme, preset, secondaryTheme } from '../../../__fixtures__/common.js';
+import { createBuildDeclarations } from '../index.js';
 
 describe('renderDeclarations', () => {
   test('renders declarations for theme with :root selector and context', () => {

--- a/src/shared/declaration/__tests__/scoped.test.ts
+++ b/src/shared/declaration/__tests__/scoped.test.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
-import { rootTheme, preset } from '../../../__fixtures__/common';
-import { Override, Theme } from '../../theme';
-import { createScopedThemeDeclarations } from '..';
+import { rootTheme, preset } from '../../../__fixtures__/common.js';
+import { Override, Theme } from '../../theme/index.js';
+import { createScopedThemeDeclarations } from '../index.js';
 
 // Scoped overrides must be complete: mode values define all states.
 const scopedOverride: Override = {

--- a/src/shared/declaration/__tests__/selector.test.ts
+++ b/src/shared/declaration/__tests__/selector.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { beforeEach, describe, test, expect } from 'vitest';
-import { Selector } from '../selector';
+import { Selector } from '../selector.js';
 
 describe('Selector', () => {
   let selector: Selector;

--- a/src/shared/declaration/__tests__/stylesheet.test.ts
+++ b/src/shared/declaration/__tests__/stylesheet.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { beforeEach, describe, test, expect } from 'vitest';
-import Stylesheet, { Declaration, Rule } from '../stylesheet';
+import Stylesheet, { Declaration, Rule } from '../stylesheet.js';
 
 describe('Stylesheet', () => {
   let stylesheet: Stylesheet;

--- a/src/shared/declaration/__tests__/transformer.test.ts
+++ b/src/shared/declaration/__tests__/transformer.test.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
-import { MinimalTransformer } from '../transformer';
-import Stylesheet, { Rule, Declaration } from '../stylesheet';
+import { MinimalTransformer } from '../transformer.js';
+import Stylesheet, { Rule, Declaration } from '../stylesheet.js';
 
 describe('MinimalTransformer', () => {
   test('removes empty global selector rules', () => {

--- a/src/shared/declaration/customizer.ts
+++ b/src/shared/declaration/customizer.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { increaseSpecificity, increaseSpecificityGradually, isIncreased } from '../styles/selector';
-import { includes } from '../utils';
+import { increaseSpecificity, increaseSpecificityGradually, isIncreased } from '../styles/selector.js';
+import { includes } from '../utils.js';
 
 export type SelectorCustomizer = (selector: string) => string;
 

--- a/src/shared/declaration/index.ts
+++ b/src/shared/declaration/index.ts
@@ -1,17 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { merge, mergeInPlace, Override, Theme } from '../theme';
-import { flattenReferenceTokens, collectReferencedTokens } from '../theme/utils';
-import type { PropertiesMap } from './interfaces';
-import type { SelectorCustomizer } from './customizer';
-import { RuleCreator } from './rule';
-import { SingleThemeCreator } from './theme-creator/single';
-import { MultiThemeCreator } from './theme-creator/multi';
-import { Selector } from './selector';
-import { MinimalTransformer } from './transformer';
-import { wrapComplexSelector } from '../styles/selector';
-import type Stylesheet from './stylesheet';
-import { cloneDeep } from '../utils';
+import { merge, mergeInPlace, Override, Theme } from '../theme/index.js';
+import { flattenReferenceTokens, collectReferencedTokens } from '../theme/utils.js';
+import type { PropertiesMap } from './interfaces.js';
+import type { SelectorCustomizer } from './customizer.js';
+import { RuleCreator } from './rule.js';
+import { SingleThemeCreator } from './theme-creator/single.js';
+import { MultiThemeCreator } from './theme-creator/multi.js';
+import { Selector } from './selector.js';
+import { MinimalTransformer } from './transformer.js';
+import { wrapComplexSelector } from '../styles/selector.js';
+import type Stylesheet from './stylesheet.js';
+import { cloneDeep } from '../utils.js';
 
 function createMinimalTheme(base: Theme, override: Override): Theme {
   const minimalTheme = cloneDeep(base);

--- a/src/shared/declaration/rule.ts
+++ b/src/shared/declaration/rule.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Selector } from './selector';
-import { Rule, Declaration } from './stylesheet';
-import { entries } from '../utils';
-import { SpecificResolution } from '../theme';
-import type { PropertiesMap } from './interfaces';
+import { Selector } from './selector.js';
+import { Rule, Declaration } from './stylesheet.js';
+import { entries } from '../utils.js';
+import { SpecificResolution } from '../theme/index.js';
+import type { PropertiesMap } from './interfaces.js';
 
 export interface SelectorConfig {
   global: string[];

--- a/src/shared/declaration/selector.ts
+++ b/src/shared/declaration/selector.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import type { SelectorCustomizer } from './customizer';
-import { isGlobalSelector } from '../styles/selector';
+import type { SelectorCustomizer } from './customizer.js';
+import { isGlobalSelector } from '../styles/selector.js';
 
 interface SelectorParams {
   global: string[];

--- a/src/shared/declaration/theme-creator/multi.ts
+++ b/src/shared/declaration/theme-creator/multi.ts
@@ -1,18 +1,26 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { isGlobalSelector } from '../../styles/selector';
-import { defaultsReducer, modeReducer, OptionalState, reduce, resolveContext, resolveTheme, Theme } from '../../theme';
-import type { PropertiesMap } from '../interfaces';
-import { RuleCreator, SelectorConfig } from '../rule';
-import { SingleThemeCreator } from './single';
-import Stylesheet, { Rule } from '../stylesheet';
+import { isGlobalSelector } from '../../styles/selector.js';
+import {
+  defaultsReducer,
+  modeReducer,
+  OptionalState,
+  reduce,
+  resolveContext,
+  resolveTheme,
+  Theme,
+} from '../../theme/index.js';
+import type { PropertiesMap } from '../interfaces.js';
+import { RuleCreator, SelectorConfig } from '../rule.js';
+import { SingleThemeCreator } from './single.js';
+import Stylesheet, { Rule } from '../stylesheet.js';
 import {
   appendRuleToStylesheet,
   compact,
   forEachContext,
   forEachContextWithinOptionalModeState,
   forEachOptionalModeState,
-} from '../utils';
+} from '../utils.js';
 
 /**
  * Extends the single theme stylesheet creator by a secondary theme, which takes the existing theme as

--- a/src/shared/declaration/theme-creator/single.ts
+++ b/src/shared/declaration/theme-creator/single.ts
@@ -9,17 +9,17 @@ import {
   resolveContext,
   resolveTheme,
   Theme,
-} from '../../theme';
-import type { PropertiesMap } from '../interfaces';
-import Stylesheet from '../stylesheet';
-import type { RuleCreator } from '../rule';
+} from '../../theme/index.js';
+import type { PropertiesMap } from '../interfaces.js';
+import Stylesheet from '../stylesheet.js';
+import type { RuleCreator } from '../rule.js';
 import {
   appendRuleToStylesheet,
   compact,
   forEachContext,
   forEachContextWithinOptionalModeState,
   forEachOptionalModeState,
-} from '../utils';
+} from '../utils.js';
 
 export class SingleThemeCreator {
   theme: Theme;

--- a/src/shared/declaration/transformer.ts
+++ b/src/shared/declaration/transformer.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { entries } from '../utils';
-import type Stylesheet from './stylesheet';
-import { Declaration } from './stylesheet';
-import { getFirstSelector, isGlobalSelector } from '../styles/selector';
-import { getReferencedVar } from './utils';
+import { entries } from '../utils.js';
+import type Stylesheet from './stylesheet.js';
+import { Declaration } from './stylesheet.js';
+import { getFirstSelector, isGlobalSelector } from '../styles/selector.js';
+import { getReferencedVar } from './utils.js';
 
 export class MinimalTransformer {
   transform(stylesheet: Stylesheet): Stylesheet {

--- a/src/shared/declaration/utils.ts
+++ b/src/shared/declaration/utils.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import type { Context, Mode, Theme } from '../theme';
-import { isOptionalState } from '../theme/utils';
-import { entries } from '../utils';
-import type Stylesheet from './stylesheet';
-import type { Rule } from './stylesheet';
+import type { Context, Mode, Theme } from '../theme/index.js';
+import { isOptionalState } from '../theme/utils.js';
+import { entries } from '../utils.js';
+import type Stylesheet from './stylesheet.js';
+import type { Rule } from './stylesheet.js';
 
 export function compact<T>(arr: (T | undefined)[]): T[] {
   const result: T[] = [];

--- a/src/shared/styles/__tests__/selector.test.ts
+++ b/src/shared/styles/__tests__/selector.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
-import { increaseSpecificity, increaseSpecificityGradually } from '../selector';
+import { increaseSpecificity, increaseSpecificityGradually } from '../selector.js';
 
 describe('Increase Specificity', () => {
   it.each([

--- a/src/shared/styles/selector.ts
+++ b/src/shared/styles/selector.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { includes } from '../utils';
+import { includes } from '../utils.js';
 
 // The idea to use a special :not(#\9) selector to increase CSS specificity came from:
 // https://github.com/MadLittleMods/postcss-increase-specificity

--- a/src/shared/theme-stylesheet.ts
+++ b/src/shared/theme-stylesheet.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ThemePreset, Override, validateOverride } from './theme';
-import { createOverrideDeclarations, createScopedThemeDeclarations } from './declaration';
-import { createMultiThemeCustomizer } from './declaration/customizer';
-import { getContexts, getThemeFromPreset, validateScopedThemeOverride } from './theme/validate';
+import { ThemePreset, Override, validateOverride } from './theme/index.js';
+import { createOverrideDeclarations, createScopedThemeDeclarations } from './declaration/index.js';
+import { createMultiThemeCustomizer } from './declaration/customizer.js';
+import { getContexts, getThemeFromPreset, validateScopedThemeOverride } from './theme/validate.js';
 
 export interface GenerateThemeStylesheetParams {
   override: Override;

--- a/src/shared/theme/__tests__/builder.test.ts
+++ b/src/shared/theme/__tests__/builder.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { beforeEach, test, expect } from 'vitest';
-import { ThemeBuilder } from '../builder';
+import { ThemeBuilder } from '../builder.js';
 
 let builder: ThemeBuilder;
 const mode = { id: 'mode', states: { mode: { default: true }, optional: { selector: '.optional' } } };

--- a/src/shared/theme/__tests__/merge.test.ts
+++ b/src/shared/theme/__tests__/merge.test.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
-import { rootTheme, override, overrideWithRandomContext } from '../../../__fixtures__/common';
-import { merge } from '../merge';
+import { rootTheme, override, overrideWithRandomContext } from '../../../__fixtures__/common.js';
+import { merge } from '../merge.js';
 
 describe('merge', () => {
   test('merges theme with override and matches previous snapshot', () => {

--- a/src/shared/theme/__tests__/process.test.ts
+++ b/src/shared/theme/__tests__/process.test.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect, vi } from 'vitest';
-import { processReferenceTokens, processColorPaletteInput } from '../process';
-import { ReferenceTokens } from '../interfaces';
+import { processReferenceTokens, processColorPaletteInput } from '../process.js';
+import { ReferenceTokens } from '../interfaces.js';
 
 // Mock the color generation utilities
 vi.mock('../color-generation/hct-utils', () => ({

--- a/src/shared/theme/__tests__/resolve.test.ts
+++ b/src/shared/theme/__tests__/resolve.test.ts
@@ -9,9 +9,9 @@ import {
   themeWithNonExistingToken,
   themeWithTokenWithoutModeResolution,
   colorMode,
-} from '../../../__fixtures__/common';
-import { resolveTheme, resolveThemeWithPaths, resolveContext } from '../resolve';
-import { Theme, Context } from '../interfaces';
+} from '../../../__fixtures__/common.js';
+import { resolveTheme, resolveThemeWithPaths, resolveContext } from '../resolve.js';
+import { Theme, Context } from '../interfaces.js';
 
 describe('resolve', () => {
   test('resolves theme to full resolution', () => {

--- a/src/shared/theme/__tests__/utils.test.ts
+++ b/src/shared/theme/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
-import { isModeValue, isValue, isReference, generateCamelCaseName, flattenObject, getReference } from '../utils';
+import { isModeValue, isValue, isReference, generateCamelCaseName, flattenObject, getReference } from '../utils.js';
 
 describe('theme utils', () => {
   describe('isModeValue', () => {

--- a/src/shared/theme/__tests__/validate.test.ts
+++ b/src/shared/theme/__tests__/validate.test.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { afterAll, beforeEach, describe, test, expect, vi, MockInstance } from 'vitest';
-import { override, presetWithSecondaryTheme, rootTheme } from '../../../__fixtures__/common';
-import { Override } from '../interfaces';
-import { validateOverride, validateScopedThemeOverride, getThemeFromPreset } from '../validate';
+import { override, presetWithSecondaryTheme, rootTheme } from '../../../__fixtures__/common.js';
+import { Override } from '../interfaces.js';
+import { validateOverride, validateScopedThemeOverride, getThemeFromPreset } from '../validate.js';
 
 let spy: MockInstance;
 beforeEach(() => {

--- a/src/shared/theme/builder.ts
+++ b/src/shared/theme/builder.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Theme, Context, Mode, ReferenceTokens } from './interfaces';
-import { processReferenceTokens } from './process';
+import { Theme, Context, Mode, ReferenceTokens } from './interfaces.js';
+import { processReferenceTokens } from './process.js';
 
 export type TokenCategory<T extends string, V> = Record<T, V>;
 

--- a/src/shared/theme/color-generation/__tests__/hct-utils.test.ts
+++ b/src/shared/theme/color-generation/__tests__/hct-utils.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
-import { hctToHex, hexToHct, createHct } from '../hct-utils';
+import { hctToHex, hexToHct, createHct } from '../hct-utils.js';
 
 describe('hct-utils', () => {
   describe('hexToHct', () => {

--- a/src/shared/theme/color-generation/__tests__/palette-generator.test.ts
+++ b/src/shared/theme/color-generation/__tests__/palette-generator.test.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
-import { generatePaletteFromSeed, clearPaletteCache } from '../palette-generator';
-import { hexToHct } from '../hct-utils';
-import { PaletteStep, ReferencePaletteDefinition } from '../../interfaces';
+import { generatePaletteFromSeed, clearPaletteCache } from '../palette-generator.js';
+import { hexToHct } from '../hct-utils.js';
+import { PaletteStep, ReferencePaletteDefinition } from '../../interfaces.js';
 
 // Helper to get color as string from palette
 function getColor(palette: ReferencePaletteDefinition, step: PaletteStep): string {

--- a/src/shared/theme/color-generation/__tests__/palette-spec.test.ts
+++ b/src/shared/theme/color-generation/__tests__/palette-spec.test.ts
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
-import { PrimaryPaletteSpecification } from '../primary-spec';
-import { NeutralPaletteSpecification } from '../neutral-spec';
-import { WarningPaletteSpecification } from '../warning-spec';
-import { hexToHct } from '../hct-utils';
-import { PaletteStep, ReferencePaletteDefinition } from '../../interfaces';
+import { PrimaryPaletteSpecification } from '../primary-spec.js';
+import { NeutralPaletteSpecification } from '../neutral-spec.js';
+import { WarningPaletteSpecification } from '../warning-spec.js';
+import { hexToHct } from '../hct-utils.js';
+import { PaletteStep, ReferencePaletteDefinition } from '../../interfaces.js';
 
 // While WCAG specifies contrast ratios (e.g., 4.5:1), the HCT (hue, chroma, tone) system converts these into a simple tone difference.
 // A difference of 40 in HCT tone guarantees a contrast ratio >= 3:1, and a difference of 50 guarantees a contrast ratio >= 4.5:1.

--- a/src/shared/theme/color-generation/__tests__/performance.test.ts
+++ b/src/shared/theme/color-generation/__tests__/performance.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { describe, test, expect } from 'vitest';
-import { generatePaletteFromSeed } from '../palette-generator';
+import { generatePaletteFromSeed } from '../palette-generator.js';
 
 describe('performance benchmarks', () => {
   test('palette generation completes within reasonable time', () => {

--- a/src/shared/theme/color-generation/neutral-spec.ts
+++ b/src/shared/theme/color-generation/neutral-spec.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { PaletteStep } from '../interfaces';
-import { createHct, Hct } from './hct-utils';
-import { PaletteSpecification } from './palette-spec';
+import { PaletteStep } from '../interfaces.js';
+import { createHct, Hct } from './hct-utils.js';
+import { PaletteSpecification } from './palette-spec.js';
 
 const MIN_TONE = 1;
 const MAX_TONE = 99;

--- a/src/shared/theme/color-generation/palette-generator.ts
+++ b/src/shared/theme/color-generation/palette-generator.ts
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ColorReferenceTokens, ReferencePaletteDefinition } from '../interfaces';
-import { NeutralPaletteSpecification } from './neutral-spec';
-import { PrimaryPaletteSpecification } from './primary-spec';
-import { WarningPaletteSpecification } from './warning-spec';
+import { ColorReferenceTokens, ReferencePaletteDefinition } from '../interfaces.js';
+import { NeutralPaletteSpecification } from './neutral-spec.js';
+import { PrimaryPaletteSpecification } from './primary-spec.js';
+import { WarningPaletteSpecification } from './warning-spec.js';
 
 // Memoization cache for palette generation
 const paletteCache = new Map<string, ReferencePaletteDefinition>();

--- a/src/shared/theme/color-generation/palette-spec.ts
+++ b/src/shared/theme/color-generation/palette-spec.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { ReferencePaletteDefinition } from '../interfaces';
-import { createHct, Hct, hctToHex, hexToHct } from './hct-utils';
+import { ReferencePaletteDefinition } from '../interfaces.js';
+import { createHct, Hct, hctToHex, hexToHct } from './hct-utils.js';
 
 interface ColorSpecification<PaletteKeys> {
   position: PaletteKeys;

--- a/src/shared/theme/color-generation/primary-spec.ts
+++ b/src/shared/theme/color-generation/primary-spec.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PaletteStep } from '../interfaces';
-import { Hct } from './hct-utils';
-import { PaletteSpecification } from './palette-spec';
+import { PaletteStep } from '../interfaces.js';
+import { Hct } from './hct-utils.js';
+import { PaletteSpecification } from './palette-spec.js';
 
 const MIN_TONE = 3;
 const MAX_TONE = 98;

--- a/src/shared/theme/color-generation/warning-spec.ts
+++ b/src/shared/theme/color-generation/warning-spec.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PaletteStep } from '../interfaces';
-import { PaletteSpecification } from './palette-spec';
+import { PaletteStep } from '../interfaces.js';
+import { PaletteSpecification } from './palette-spec.js';
 
 const MIN_TONE = 5;
 const MAX_TONE = 98;

--- a/src/shared/theme/index.ts
+++ b/src/shared/theme/index.ts
@@ -14,8 +14,8 @@ export {
   ReferenceTokens,
   ColorReferenceTokens,
   ReferencePaletteDefinition,
-} from './interfaces';
-export { ThemeBuilder, TokenCategory } from './builder';
+} from './interfaces.js';
+export { ThemeBuilder, TokenCategory } from './builder.js';
 export {
   resolveTheme,
   resolveThemeWithPaths,
@@ -27,7 +27,7 @@ export {
   FullResolution,
   SpecificResolution,
   FullResolutionPaths,
-} from './resolve';
-export { validateOverride } from './validate';
-export { merge, mergeInPlace } from './merge';
-export { processColorPaletteInput } from './process';
+} from './resolve.js';
+export { validateOverride } from './validate.js';
+export { merge, mergeInPlace } from './merge.js';
+export { processColorPaletteInput } from './process.js';

--- a/src/shared/theme/merge.ts
+++ b/src/shared/theme/merge.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Theme, Override, Assignment } from './interfaces';
-import { cloneDeep, entries } from '../utils';
-import { getMode, isModeValue, isReference, isValue } from './utils';
+import { Theme, Override, Assignment } from './interfaces.js';
+import { cloneDeep, entries } from '../utils.js';
+import { getMode, isModeValue, isReference, isValue } from './utils.js';
 
 /**
  * This function applies all tokens from the override to the theme.

--- a/src/shared/theme/process.ts
+++ b/src/shared/theme/process.ts
@@ -1,14 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { generatePaletteFromSeed } from './color-generation/palette-generator';
+import { generatePaletteFromSeed } from './color-generation/palette-generator.js';
 import {
   ColorReferenceTokens,
   ColorPaletteInput,
   PaletteStep,
   ReferencePaletteDefinition,
   Assignment,
-} from './interfaces';
-import { generateReferenceTokenName, isValidPaletteStep } from './utils';
+} from './interfaces.js';
+import { generateReferenceTokenName, isValidPaletteStep } from './utils.js';
 
 export type TokenCategory<T extends string, V> = Record<T, V>;
 

--- a/src/shared/theme/resolve.ts
+++ b/src/shared/theme/resolve.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Context, Mode } from '.';
-import { cloneDeep, values } from '../utils';
-import { Theme, Value } from './interfaces';
-import type { PropertiesMap } from '../declaration/interfaces';
+import { Context, Mode } from './index.js';
+import { cloneDeep, values } from '../utils.js';
+import { Theme, Value } from './interfaces.js';
+import type { PropertiesMap } from '../declaration/interfaces.js';
 import {
   areAssignmentsEqual,
   getDefaultState,
@@ -12,7 +12,7 @@ import {
   isModeValue,
   isReference,
   isReferenceToken,
-} from './utils';
+} from './utils.js';
 
 export type ModeTokenResolution = Record<string, Value>;
 export type SpecificTokenResolution = Value;

--- a/src/shared/theme/utils.ts
+++ b/src/shared/theme/utils.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Assignment, DefaultState, OptionalState, ReferenceTokens, Theme } from './interfaces';
-import { Value, Reference, ModeValue, Mode } from './interfaces';
+import { Assignment, DefaultState, OptionalState, ReferenceTokens, Theme } from './interfaces.js';
+import { Value, Reference, ModeValue, Mode } from './interfaces.js';
 
 export function isReferenceToken(category: keyof ReferenceTokens, theme: Theme, token: string): boolean {
   const categoryTokens = theme.referenceTokens?.[category];

--- a/src/shared/theme/validate.ts
+++ b/src/shared/theme/validate.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { entries, fromEntries, includes } from '../utils';
-import { Override, Theme, ThemePreset, Token } from './interfaces';
-import { processReferenceTokens } from './process';
-import { getMode } from './utils';
+import { entries, fromEntries, includes } from '../utils.js';
+import { Override, Theme, ThemePreset, Token } from './interfaces.js';
+import { processReferenceTokens } from './process.js';
+import { getMode } from './utils.js';
 
 /**
  * This function compares the theme override against the list of tokens that are allowed


### PR DESCRIPTION
Part of cloudscape-design/components#4948, and splits the mechanical half out of #199.

`lib/browser` emits ESM. Node's ESM resolver neither probes extensions nor falls back to a directory index, so importing the built package fails before any of it runs:

```
$ node -e "import('./lib/browser/browser/index.js')"
ERR_MODULE_NOT_FOUND: Cannot find module '.../lib/browser/shared/theme-stylesheet'
imported from '.../lib/browser/browser/index.js'
```

TypeScript passes relative specifiers through to the emitted JavaScript verbatim, so the fix belongs in source. Applied with the `require-emitted-extensions` autofix (cloudscape-design/build-tools#77) over `src/browser` and `src/shared`, which are what compile into `lib/browser`: 138 specifiers across 44 files, nothing unresolvable or ambiguous, and a second pass changes nothing. The only hand edit is a prettier rewrap where one import grew past the print width.

`src/build` is left alone. It compiles to `lib/node`, which is CommonJS, where an extensionless specifier resolves. `src/shared` compiles into both outputs, and naming the emitted file is right for each: CommonJS resolves `require("./builder.js")` as readily as `require("./builder")`.

## Verification

With the change the built entry loads; without it, same build, it fails as above.

- `tsc -p tsconfig.test.json --noEmit`: clean (TypeScript 4.9.5, `moduleResolution: node`, which maps a `.js` specifier back to the `.ts` source).
- `npm run build`: clean.
- `npm run lint`: 0 errors, 53 pre-existing warnings.
- `npm run test:build`: 358 tests / 36 files. `npm run test:browser`: 249 tests / 19 files.
- `require('./lib/node/build/index.js')` still loads, confirming the CommonJS output is unaffected.
- `test:integ` not run locally, since it spawns Chrome.

## Separate gap, not fixed here

`lib/browser/package.json` sets no `"type"`, so that ESM output is typeless. Node 24 loads it only via module-syntax detection, with a `MODULE_TYPELESS_PACKAGE_JSON` warning; older Node treats it as CommonJS and throws a SyntaxError. Worth a follow-up, but it is a packaging decision rather than part of this rewrite.
