### PR TITLE
chore: Bump joi to 18.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6333,9 +6333,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.2.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
-      "integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
+      "version": "18.2.8",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.8.tgz",
+      "integrity": "sha512-G2TX62h58ZHuwqetJgP2F4ualakqAmZtBYe3jWen7gxQRw5xApX6crnFtuB91WC0c3ESBnva+kGSnb3+6pIQDQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",


### PR DESCRIPTION
Splice joi 18.2.3 -> 18.2.8 (transitive via browser-test-tools -> wait-on), addressing Dependabot alerts GHSA-6w3j-5fw6-r9vr and GHSA-gg4h-3hg2-grpc. joi 18.2.8 has an identical dependency set, so this is a lockfile-only change with no other packages affected. Target version confirmed available internally.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
