### PR TITLE
chore: Use correct resolution extension for preset declaration files

### DIFF
--- a/src/build/tasks/preset.ts
+++ b/src/build/tasks/preset.ts
@@ -14,7 +14,7 @@ export async function createPresetFiles(preset: ThemePreset, outputDir: string) 
     writeFile(join(generatedDir, '/index.js'), renderPreset(preset)),
     writeFile(join(generatedDir, '/index.cjs'), renderCJSPreset(preset)),
     writeFile(join(generatedDir, '/index.d.ts'), renderPresetDeclaration(preset)),
-    writeFile(join(generatedDir, '/index.cjs.d.ts'), renderCJSPresetDeclaration(preset)),
+    writeFile(join(generatedDir, '/index.d.cts'), renderCJSPresetDeclaration(preset)),
   ]);
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Found while importing the type; the .cjs version is resolved in Node.js, but the typings aren't matched properly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
